### PR TITLE
Flag `--default-http-code` for the `serve` subcommand added

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -196,12 +196,12 @@ jobs: # Docs: <https://git.io/JvxXE>
         run: docker load < docker-image.tar
 
       - name: Run container with the app
-        run: docker run --rm -d -p "8080:8080/tcp" --name app app:ci
+        run: docker run --rm -d -p "8080:8080/tcp" --name app app:ci --default-http-code 401
 
       - name: Wait for container "healthy" state
         run: until [[ "`docker inspect -f {{.State.Health.Status}} app`" == "healthy" ]]; do echo "wait 1 sec.."; sleep 1; done
 
-      - run: curl --fail http://127.0.0.1:8080/
+      - run: test $(curl --write-out %{http_code} --silent --output /dev/null http://127.0.0.1:8080/) -eq 401
       - run: curl --fail http://127.0.0.1:8080/500.html
       - run: curl --fail http://127.0.0.1:8080/400.html
       - run: curl --fail http://127.0.0.1:8080/health/live

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -196,7 +196,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         run: docker load < docker-image.tar
 
       - name: Run container with the app
-        run: docker run --rm -d -p "8080:8080/tcp" --name app app:ci --default-http-code 401
+        run: docker run --rm -d -p "8080:8080/tcp" -e "DEFAULT_HTTP_CODE=401" --name app app:ci
 
       - name: Wait for container "healthy" state
         run: until [[ "`docker inspect -f {{.State.Health.Status}} app`" == "healthy" ]]; do echo "wait 1 sec.."; sleep 1; done

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,8 @@ run:
   skip-dirs:
     - .github
     - .git
+    - tmp
+    - temp
   modules-download-mode: readonly
   allow-parallel-runners: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ## UNRELEASED
 
+### Added
+
+- Flag `--default-http-code` for the `serve` subcommand (`404` is used by default instead of `200`, environment name `DEFAULT_HTTP_CODE`) [#41]
+
 ### Changed
 
 - Go updated from `1.17.1` up to `1.17.5`
 
-### Added
-
-- Flag `--default-http-code` for the `serve` subcommand (`404` is used by default instead of `200`, environment name `DEFAULT_HTTP_CODE`)
+[#41]:https://github.com/tarampampam/error-pages/issues/41
 
 ## v2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 - Go updated from `1.17.1` up to `1.17.5`
 
+### Added
+
+- Flag `--default-http-code` for the `serve` subcommand (`404` is used by default instead of `200`, environment name `DEFAULT_HTTP_CODE`)
+
 ## v2.2.0
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,8 @@ WORKDIR /opt
 
 ENV LISTEN_PORT="8080" \
     TEMPLATE_NAME="ghost" \
-    DEFAULT_ERROR_PAGE="404"
+    DEFAULT_ERROR_PAGE="404" \
+    DEFAULT_HTTP_CODE="404"
 
 # Docs: <https://docs.docker.com/engine/reference/builder/#healthcheck>
 HEALTHCHECK --interval=7s --timeout=2s CMD [ \

--- a/internal/cli/serve/command.go
+++ b/internal/cli/serve/command.go
@@ -144,7 +144,7 @@ func run(parentCtx context.Context, log *zap.Logger, f flags, cfg *config.Config
 	server := appHttp.NewServer(log)
 
 	// register server routes, middlewares, etc.
-	server.Register(&errorPages, picker, f.defaultErrorPage)
+	server.Register(&errorPages, picker, f.defaultErrorPage, f.defaultHTTPCode)
 
 	startedAt, startingErrCh := time.Now(), make(chan error, 1) // channel for server starting error
 
@@ -156,6 +156,7 @@ func run(parentCtx context.Context, log *zap.Logger, f flags, cfg *config.Config
 			zap.String("addr", f.listen.ip),
 			zap.Uint16("port", f.listen.port),
 			zap.String("default error page", f.defaultErrorPage),
+			zap.Uint16("default HTTP response code", f.defaultHTTPCode),
 		)
 
 		if err := server.Start(f.listen.ip, f.listen.port); err != nil {

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -11,6 +11,7 @@ const (
 	TemplateName     envVariable = "TEMPLATE_NAME"      // template name
 	ConfigFilePath   envVariable = "CONFIG_FILE"        // path to the config file
 	DefaultErrorPage envVariable = "DEFAULT_ERROR_PAGE" // default error page (code)
+	DefaultHTTPCode  envVariable = "DEFAULT_HTTP_CODE"  // default HTTP response code
 )
 
 // String returns environment variable name in the string representation.

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -13,6 +13,7 @@ func TestConstants(t *testing.T) {
 	assert.Equal(t, "TEMPLATE_NAME", string(TemplateName))
 	assert.Equal(t, "CONFIG_FILE", string(ConfigFilePath))
 	assert.Equal(t, "DEFAULT_ERROR_PAGE", string(DefaultErrorPage))
+	assert.Equal(t, "DEFAULT_HTTP_CODE", string(DefaultHTTPCode))
 }
 
 func TestEnvVariable_Lookup(t *testing.T) {
@@ -24,6 +25,7 @@ func TestEnvVariable_Lookup(t *testing.T) {
 		{giveEnv: TemplateName},
 		{giveEnv: ConfigFilePath},
 		{giveEnv: DefaultErrorPage},
+		{giveEnv: DefaultHTTPCode},
 	}
 
 	for _, tt := range cases {

--- a/internal/http/handlers/index/handler.go
+++ b/internal/http/handlers/index/handler.go
@@ -17,13 +17,18 @@ type (
 )
 
 // NewHandler creates handler for the index page serving.
-func NewHandler(e errorsPager, p templatePicker, defaultPageCode string) fasthttp.RequestHandler {
+func NewHandler(
+	e errorsPager,
+	p templatePicker,
+	defaultPageCode string,
+	defaultHTTPCode uint16,
+) fasthttp.RequestHandler {
 	return func(ctx *fasthttp.RequestCtx) {
 		content, err := e.GetPage(p.Pick(), defaultPageCode)
 
 		if err == nil {
 			ctx.SetContentType("text/html; charset=utf-8")
-			ctx.SetStatusCode(fasthttp.StatusOK)
+			ctx.SetStatusCode(int(defaultHTTPCode))
 			_, _ = ctx.Write(content)
 
 			return

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -66,8 +66,13 @@ type (
 
 // Register server routes, middlewares, etc.
 // Router docs: <https://github.com/fasthttp/router>
-func (s *Server) Register(errorsPager errorsPager, templatePicker templatePicker, defaultPageCode string) {
-	s.router.GET("/", indexHandler.NewHandler(errorsPager, templatePicker, defaultPageCode))
+func (s *Server) Register(
+	errorsPager errorsPager,
+	templatePicker templatePicker,
+	defaultPageCode string,
+	defaultHTTPCode uint16,
+) {
+	s.router.GET("/", indexHandler.NewHandler(errorsPager, templatePicker, defaultPageCode, defaultHTTPCode))
 	s.router.GET("/version", versionHandler.NewHandler(version.Version()))
 	s.router.ANY("/health/live", healthzHandler.NewHandler(checkers.NewLiveChecker()))
 	s.router.GET("/{code}.html", errorpageHandler.NewHandler(errorsPager, templatePicker))


### PR DESCRIPTION
## Description

### Added

- Flag `--default-http-code` for the `serve` subcommand (`404` is used by default instead of `200`, environment name `DEFAULT_HTTP_CODE`)

Issue #41

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
