### PR TITLE
proxy headers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -226,7 +226,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         run: sudo dpkg -i hurl.deb
 
       - name: Run container with the app
-        run: docker run --rm -d -p "8080:8080/tcp" -e "SHOW_DETAILS=true" --name app app:ci
+        run: docker run --rm -d -p "8080:8080/tcp" -e "SHOW_DETAILS=true" -e "PROXY_HTTP_HEADERS=X-Foo,Bar,Baz_blah" --name app app:ci
 
       - name: Wait for container "healthy" state
         run: until [[ "`docker inspect -f {{.State.Health.Status}} app`" == "healthy" ]]; do echo "wait 1 sec.."; sleep 1; done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Changed
 
-- Logs includes request/response headers now
+- Logs includes request/response headers now [#67]
 
 ### Added
 
-- Possibility to proxy HTTP headers from the requests to the responses (can be enabled using `--proxy-headers` flag for the `serve` command or environment variable `PROXY_HTTP_HEADERS`, comma-separated)
+- Possibility to proxy HTTP headers from the requests to the responses (can be enabled using `--proxy-headers` flag for the `serve` command or environment variable `PROXY_HTTP_HEADERS`, comma-separated) [#67]
+
+[#67]:https://github.com/tarampampam/error-pages/pull/67
 
 ## v2.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## UNRELEASED
+
+### Changed
+
+- Logs includes request/response headers now
+
+### Added
+
+- Possibility to proxy HTTP headers from the requests to the responses (can be enabled using `--proxy-headers` flag for the `serve` command or environment variable `PROXY_HTTP_HEADERS`, comma-separated)
+
 ## v2.6.0
 
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - --verbose
       - --port=8080
       - --show-details
+      - --proxy-headers=X-Foo,Bar,Baz_blah
     healthcheck:
       test: ['CMD', 'wget', '--spider', '-q', 'http://127.0.0.1:8080/healthz']
       interval: 5s

--- a/internal/cli/serve/command.go
+++ b/internal/cli/serve/command.go
@@ -107,11 +107,20 @@ func run(parentCtx context.Context, log *zap.Logger, f flags, cfg *config.Config
 		}
 	}
 
+	var proxyHTTPHeaders = f.HeadersToProxy()
+
 	// create HTTP server
 	server := appHttp.NewServer(log)
 
 	// register server routes, middlewares, etc.
-	if err := server.Register(cfg, picker, f.defaultErrorPage, f.defaultHTTPCode, f.showDetails); err != nil {
+	if err := server.Register(
+		cfg,
+		picker,
+		f.defaultErrorPage,
+		f.defaultHTTPCode,
+		f.showDetails,
+		proxyHTTPHeaders,
+	); err != nil {
 		return err
 	}
 
@@ -126,6 +135,7 @@ func run(parentCtx context.Context, log *zap.Logger, f flags, cfg *config.Config
 			zap.Uint16("port", f.listen.port),
 			zap.String("default error page", f.defaultErrorPage),
 			zap.Uint16("default HTTP response code", f.defaultHTTPCode),
+			zap.Strings("proxy headers", proxyHTTPHeaders),
 			zap.Bool("show request details", f.showDetails),
 		)
 

--- a/internal/cli/serve/flags.go
+++ b/internal/cli/serve/flags.go
@@ -33,15 +33,21 @@ func (f *flags) HeadersToProxy() []string {
 	if len(raw) == 0 {
 		return []string{}
 	} else if len(raw) == 1 {
-		return []string{raw[0]}
+		if h := strings.TrimSpace(raw[0]); h != "" {
+			return []string{h}
+		} else {
+			return []string{}
+		}
 	}
 
 	var m = make(map[string]struct{}, len(raw))
 
-	// make unique
+	// make unique and ignore empty strings
 	for _, h := range raw {
-		if _, ok := m[h]; !ok {
-			m[h] = struct{}{}
+		if h = strings.TrimSpace(h); h != "" {
+			if _, ok := m[h]; !ok {
+				m[h] = struct{}{}
+			}
 		}
 	}
 

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -13,6 +13,7 @@ const (
 	DefaultErrorPage envVariable = "DEFAULT_ERROR_PAGE" // default error page (code)
 	DefaultHTTPCode  envVariable = "DEFAULT_HTTP_CODE"  // default HTTP response code
 	ShowDetails      envVariable = "SHOW_DETAILS"       // show request details in response
+	ProxyHTTPHeaders envVariable = "PROXY_HTTP_HEADERS" // proxy HTTP request headers list (request -> response)
 )
 
 // String returns environment variable name in the string representation.

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -15,6 +15,7 @@ func TestConstants(t *testing.T) {
 	assert.Equal(t, "DEFAULT_ERROR_PAGE", string(DefaultErrorPage))
 	assert.Equal(t, "DEFAULT_HTTP_CODE", string(DefaultHTTPCode))
 	assert.Equal(t, "SHOW_DETAILS", string(ShowDetails))
+	assert.Equal(t, "PROXY_HTTP_HEADERS", string(ProxyHTTPHeaders))
 }
 
 func TestEnvVariable_Lookup(t *testing.T) {
@@ -28,6 +29,7 @@ func TestEnvVariable_Lookup(t *testing.T) {
 		{giveEnv: DefaultErrorPage},
 		{giveEnv: DefaultHTTPCode},
 		{giveEnv: ShowDetails},
+		{giveEnv: ProxyHTTPHeaders},
 	}
 
 	for _, tt := range cases {

--- a/internal/http/handlers/errorpage/handler.go
+++ b/internal/http/handlers/errorpage/handler.go
@@ -19,12 +19,18 @@ type (
 )
 
 // NewHandler creates handler for error pages serving.
-func NewHandler(cfg *config.Config, p templatePicker, rdr renderer, showRequestDetails bool) fasthttp.RequestHandler {
+func NewHandler(
+	cfg *config.Config,
+	p templatePicker,
+	rdr renderer,
+	showRequestDetails bool,
+	proxyHTTPHeaders []string,
+) fasthttp.RequestHandler {
 	return func(ctx *fasthttp.RequestCtx) {
 		core.SetClientFormat(ctx, core.PlainTextContentType) // default content type
 
 		if code, ok := ctx.UserValue("code").(string); ok {
-			core.RespondWithErrorPage(ctx, cfg, p, rdr, code, fasthttp.StatusOK, showRequestDetails)
+			core.RespondWithErrorPage(ctx, cfg, p, rdr, code, fasthttp.StatusOK, showRequestDetails, proxyHTTPHeaders)
 		} else { // will never occur
 			ctx.SetStatusCode(fasthttp.StatusInternalServerError)
 			_, _ = ctx.WriteString("cannot extract requested code from the request")

--- a/internal/http/handlers/index/handler.go
+++ b/internal/http/handlers/index/handler.go
@@ -28,6 +28,7 @@ func NewHandler(
 	defaultPageCode string,
 	defaultHTTPCode uint16,
 	showRequestDetails bool,
+	proxyHTTPHeaders []string,
 ) fasthttp.RequestHandler {
 	return func(ctx *fasthttp.RequestCtx) {
 		pageCode, httpCode := defaultPageCode, int(defaultHTTPCode)
@@ -36,7 +37,7 @@ func NewHandler(
 			pageCode, httpCode = strconv.Itoa(returnCode), returnCode
 		}
 
-		core.RespondWithErrorPage(ctx, cfg, p, rdr, pageCode, httpCode, showRequestDetails)
+		core.RespondWithErrorPage(ctx, cfg, p, rdr, pageCode, httpCode, showRequestDetails, proxyHTTPHeaders)
 	}
 }
 

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -72,6 +72,7 @@ func (s *Server) Register(
 	defaultPageCode string,
 	defaultHTTPCode uint16,
 	showDetails bool,
+	proxyHTTPHeaders []string,
 ) error {
 	reg, m := metrics.NewRegistry(), metrics.NewMetrics()
 
@@ -81,8 +82,8 @@ func (s *Server) Register(
 
 	s.fast.Handler = common.DurationMetrics(common.LogRequest(s.router.Handler, s.log), &m)
 
-	s.router.GET("/", indexHandler.NewHandler(cfg, templatePicker, s.rdr, defaultPageCode, defaultHTTPCode, showDetails)) //nolint:lll
-	s.router.GET("/{code}.html", errorpageHandler.NewHandler(cfg, templatePicker, s.rdr, showDetails))
+	s.router.GET("/", indexHandler.NewHandler(cfg, templatePicker, s.rdr, defaultPageCode, defaultHTTPCode, showDetails, proxyHTTPHeaders)) //nolint:lll
+	s.router.GET("/{code}.html", errorpageHandler.NewHandler(cfg, templatePicker, s.rdr, showDetails, proxyHTTPHeaders))                    //nolint:lll
 	s.router.GET("/version", versionHandler.NewHandler(version.Version()))
 
 	liveHandler := healthzHandler.NewHandler(checkers.NewLiveChecker())

--- a/test/hurl/proxy_headers.hurl
+++ b/test/hurl/proxy_headers.hurl
@@ -1,0 +1,13 @@
+GET http://{{ host }}:{{ port }}/502.html
+X-Foo: foo
+bar: BAR
+Baz_blah: baz Baz
+NonEx: skip
+
+HTTP/* 200
+
+[Asserts]
+header "X-Foo" == "foo"
+header "Bar" == "BAR"
+header "Baz_blah" == "baz Baz"
+header "NonEx" not exists


### PR DESCRIPTION
## Description

### Changed

- Logs includes request/response headers now

### Added

- Possibility to proxy HTTP headers from the requests to the responses (can be enabled using `--proxy-headers` flag for the `serve` command or environment variable `PROXY_HTTP_HEADERS`, comma-separated)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
