### PR TITLE
Added possibility to disable error pages auto-localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## UNRELEASED
+
+### Added
+
+- Possibility to disable error pages auto-localization (using `--disable-l10n` flag for the `serve` & `build` commands or environment variable `DISABLE_L10N`)
+
 ## v2.12.1
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,8 @@ ENV LISTEN_PORT="8080" \
     TEMPLATE_NAME="ghost" \
     DEFAULT_ERROR_PAGE="404" \
     DEFAULT_HTTP_CODE="404" \
-    SHOW_DETAILS="false"
+    SHOW_DETAILS="false" \
+    DISABLE_L10N="false"
 
 # Docs: <https://docs.docker.com/engine/reference/builder/#healthcheck>
 HEALTHCHECK --interval=7s --timeout=2s CMD ["/bin/error-pages", "healthcheck", "--log-json"]

--- a/internal/cli/build/command.go
+++ b/internal/cli/build/command.go
@@ -15,6 +15,7 @@ import (
 func NewCommand(log *zap.Logger, configFile *string) *cobra.Command {
 	var (
 		generateIndex bool
+		disableL10n   bool
 		cfg           *config.Config
 	)
 
@@ -39,7 +40,7 @@ func NewCommand(log *zap.Logger, configFile *string) *cobra.Command {
 				return errors.New("wrong arguments count")
 			}
 
-			return run(log, cfg, args[0], generateIndex)
+			return run(log, cfg, args[0], generateIndex, disableL10n)
 		},
 	}
 
@@ -48,6 +49,13 @@ func NewCommand(log *zap.Logger, configFile *string) *cobra.Command {
 		"index", "i",
 		false,
 		"generate index page",
+	)
+
+	cmd.Flags().BoolVarP(
+		&disableL10n,
+		"disable-l10n", "",
+		false,
+		"disable error pages localization",
 	)
 
 	return cmd
@@ -60,7 +68,7 @@ const (
 	outDirPerm       = os.FileMode(0775)
 )
 
-func run(log *zap.Logger, cfg *config.Config, outDirectoryPath string, generateIndex bool) error { //nolint:funlen
+func run(log *zap.Logger, cfg *config.Config, outDirectoryPath string, generateIndex, disableL10n bool) error { //nolint:funlen,lll
 	if len(cfg.Templates) == 0 {
 		return errors.New("no loaded templates")
 	}
@@ -92,6 +100,7 @@ func run(log *zap.Logger, cfg *config.Config, outDirectoryPath string, generateI
 				Message:            page.Message(),
 				Description:        page.Description(),
 				ShowRequestDetails: false,
+				L10nDisabled:       disableL10n,
 			})
 			if renderingErr != nil {
 				return renderingErr

--- a/internal/cli/serve/command.go
+++ b/internal/cli/serve/command.go
@@ -120,6 +120,7 @@ func run(parentCtx context.Context, log *zap.Logger, f flags, cfg *config.Config
 		f.defaultHTTPCode,
 		f.showDetails,
 		proxyHTTPHeaders,
+		f.l10n.disabled,
 	); err != nil {
 		return err
 	}
@@ -137,6 +138,7 @@ func run(parentCtx context.Context, log *zap.Logger, f flags, cfg *config.Config
 			zap.Uint16("default HTTP response code", f.defaultHTTPCode),
 			zap.Strings("proxy headers", proxyHTTPHeaders),
 			zap.Bool("show request details", f.showDetails),
+			zap.Bool("localization disabled", f.l10n.disabled),
 		)
 
 		if err := server.Start(f.listen.ip, f.listen.port); err != nil {

--- a/internal/cli/serve/flags.go
+++ b/internal/cli/serve/flags.go
@@ -19,6 +19,9 @@ type flags struct {
 	template struct {
 		name string
 	}
+	l10n struct {
+		disabled bool
+	}
 	defaultErrorPage string
 	defaultHTTPCode  uint16
 	showDetails      bool
@@ -71,6 +74,7 @@ const (
 	defaultHTTPCodeFlagName  = "default-http-code"
 	showDetailsFlagName      = "show-details"
 	proxyHTTPHeadersFlagName = "proxy-headers"
+	disableL10nFlagName      = "disable-l10n"
 )
 
 const (
@@ -131,6 +135,12 @@ func (f *flags) init(flagSet *pflag.FlagSet) {
 		"",
 		fmt.Sprintf("proxy HTTP request headers list (comma-separated) [$%s]", env.ProxyHTTPHeaders),
 	)
+	flagSet.BoolVarP(
+		&f.l10n.disabled,
+		disableL10nFlagName, "",
+		false,
+		fmt.Sprintf("disable error pages localization [$%s]", env.DisableL10n),
+	)
 }
 
 func (f *flags) overrideUsingEnv(flagSet *pflag.FlagSet) (lastErr error) { //nolint:gocognit,gocyclo
@@ -181,6 +191,13 @@ func (f *flags) overrideUsingEnv(flagSet *pflag.FlagSet) (lastErr error) { //nol
 			case proxyHTTPHeadersFlagName:
 				if envVar, exists := env.ProxyHTTPHeaders.Lookup(); exists {
 					f.proxyHTTPHeaders = strings.TrimSpace(envVar)
+				}
+
+			case disableL10nFlagName:
+				if envVar, exists := env.DisableL10n.Lookup(); exists {
+					if b, err := strconv.ParseBool(envVar); err == nil {
+						f.l10n.disabled = b
+					}
 				}
 			}
 		}

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -14,6 +14,7 @@ const (
 	DefaultHTTPCode  envVariable = "DEFAULT_HTTP_CODE"  // default HTTP response code
 	ShowDetails      envVariable = "SHOW_DETAILS"       // show request details in response
 	ProxyHTTPHeaders envVariable = "PROXY_HTTP_HEADERS" // proxy HTTP request headers list (request -> response)
+	DisableL10n      envVariable = "DISABLE_L10N"       // disable pages localization
 )
 
 // String returns environment variable name in the string representation.

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -16,6 +16,7 @@ func TestConstants(t *testing.T) {
 	assert.Equal(t, "DEFAULT_HTTP_CODE", string(DefaultHTTPCode))
 	assert.Equal(t, "SHOW_DETAILS", string(ShowDetails))
 	assert.Equal(t, "PROXY_HTTP_HEADERS", string(ProxyHTTPHeaders))
+	assert.Equal(t, "DISABLE_L10N", string(DisableL10n))
 }
 
 func TestEnvVariable_Lookup(t *testing.T) {
@@ -30,6 +31,7 @@ func TestEnvVariable_Lookup(t *testing.T) {
 		{giveEnv: DefaultHTTPCode},
 		{giveEnv: ShowDetails},
 		{giveEnv: ProxyHTTPHeaders},
+		{giveEnv: DisableL10n},
 	}
 
 	for _, tt := range cases {

--- a/internal/http/core/errorpage.go
+++ b/internal/http/core/errorpage.go
@@ -26,6 +26,7 @@ func RespondWithErrorPage( //nolint:funlen,gocyclo
 	httpCode int,
 	showRequestDetails bool,
 	proxyHeaders []string,
+	disableL10n bool,
 ) {
 	ctx.Response.Header.Set("X-Robots-Tag", "noindex") // block Search indexing
 
@@ -33,7 +34,7 @@ func RespondWithErrorPage( //nolint:funlen,gocyclo
 		clientWant    = ClientWantFormat(ctx)
 		json, canJSON = cfg.JSONFormat()
 		xml, canXML   = cfg.XMLFormat()
-		props         = tpl.Properties{Code: pageCode, ShowRequestDetails: showRequestDetails}
+		props         = tpl.Properties{Code: pageCode, ShowRequestDetails: showRequestDetails, L10nDisabled: disableL10n}
 	)
 
 	if showRequestDetails {

--- a/internal/http/handlers/errorpage/handler.go
+++ b/internal/http/handlers/errorpage/handler.go
@@ -25,12 +25,23 @@ func NewHandler(
 	rdr renderer,
 	showRequestDetails bool,
 	proxyHTTPHeaders []string,
+	disableL10n bool,
 ) fasthttp.RequestHandler {
 	return func(ctx *fasthttp.RequestCtx) {
 		core.SetClientFormat(ctx, core.PlainTextContentType) // default content type
 
 		if code, ok := ctx.UserValue("code").(string); ok {
-			core.RespondWithErrorPage(ctx, cfg, p, rdr, code, fasthttp.StatusOK, showRequestDetails, proxyHTTPHeaders)
+			core.RespondWithErrorPage(
+				ctx,
+				cfg,
+				p,
+				rdr,
+				code,
+				fasthttp.StatusOK,
+				showRequestDetails,
+				proxyHTTPHeaders,
+				disableL10n,
+			)
 		} else { // will never occur
 			ctx.SetStatusCode(fasthttp.StatusInternalServerError)
 			_, _ = ctx.WriteString("cannot extract requested code from the request")

--- a/internal/http/handlers/index/handler.go
+++ b/internal/http/handlers/index/handler.go
@@ -29,6 +29,7 @@ func NewHandler(
 	defaultHTTPCode uint16,
 	showRequestDetails bool,
 	proxyHTTPHeaders []string,
+	disableL10n bool,
 ) fasthttp.RequestHandler {
 	return func(ctx *fasthttp.RequestCtx) {
 		pageCode, httpCode := defaultPageCode, int(defaultHTTPCode)
@@ -37,7 +38,7 @@ func NewHandler(
 			pageCode, httpCode = strconv.Itoa(returnCode), returnCode
 		}
 
-		core.RespondWithErrorPage(ctx, cfg, p, rdr, pageCode, httpCode, showRequestDetails, proxyHTTPHeaders)
+		core.RespondWithErrorPage(ctx, cfg, p, rdr, pageCode, httpCode, showRequestDetails, proxyHTTPHeaders, disableL10n)
 	}
 }
 

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -73,6 +73,7 @@ func (s *Server) Register(
 	defaultHTTPCode uint16,
 	showDetails bool,
 	proxyHTTPHeaders []string,
+	disableL10n bool,
 ) error {
 	reg, m := metrics.NewRegistry(), metrics.NewMetrics()
 
@@ -82,8 +83,25 @@ func (s *Server) Register(
 
 	s.fast.Handler = common.DurationMetrics(common.LogRequest(s.router.Handler, s.log), &m)
 
-	s.router.GET("/", indexHandler.NewHandler(cfg, templatePicker, s.rdr, defaultPageCode, defaultHTTPCode, showDetails, proxyHTTPHeaders)) //nolint:lll
-	s.router.GET("/{code}.html", errorpageHandler.NewHandler(cfg, templatePicker, s.rdr, showDetails, proxyHTTPHeaders))                    //nolint:lll
+	s.router.GET("/", indexHandler.NewHandler(
+		cfg,
+		templatePicker,
+		s.rdr,
+		defaultPageCode,
+		defaultHTTPCode,
+		showDetails,
+		proxyHTTPHeaders,
+		disableL10n,
+	))
+	s.router.GET("/{code}.html", errorpageHandler.NewHandler(
+		cfg,
+		templatePicker,
+		s.rdr,
+		showDetails,
+		proxyHTTPHeaders,
+		disableL10n,
+	))
+
 	s.router.GET("/version", versionHandler.NewHandler(version.Version()))
 
 	liveHandler := healthzHandler.NewHandler(checkers.NewLiveChecker())

--- a/internal/tpl/properties.go
+++ b/internal/tpl/properties.go
@@ -16,6 +16,7 @@ type Properties struct { // only string properties with a "token" tag, please
 	RequestID          string `token:"request_id"`
 	ForwardedFor       string `token:"forwarded_for"`
 	Host               string `token:"host"`
+	L10nDisabled       bool
 	ShowRequestDetails bool
 }
 

--- a/internal/tpl/render.go
+++ b/internal/tpl/render.go
@@ -140,8 +140,10 @@ func (tr *TemplateRenderer) Render(content []byte, props Properties) ([]byte, er
 	}
 
 	var funcMap = template.FuncMap{
-		"show_details": func() bool { return props.ShowRequestDetails },
-		"hide_details": func() bool { return !props.ShowRequestDetails },
+		"show_details":  func() bool { return props.ShowRequestDetails },
+		"hide_details":  func() bool { return !props.ShowRequestDetails },
+		"l10n_disabled": func() bool { return props.L10nDisabled },
+		"l10n_enabled":  func() bool { return !props.L10nDisabled },
 	}
 
 	// make a copy of template functions map

--- a/internal/tpl/render_test.go
+++ b/internal/tpl/render_test.go
@@ -56,6 +56,17 @@ func Test_Render(t *testing.T) {
 			giveProps:   tpl.Properties{Code: "201", Message: "lorem ipsum"},
 			wantContent: `{"code": "201", "message": {"here":[ " Yeah " ]}}`,
 		},
+
+		"fn l10n_enabled": {
+			giveContent: "{{ if l10n_enabled }}Y{{ else }}N{{ end }}",
+			giveProps:   tpl.Properties{L10nDisabled: true},
+			wantContent: "N",
+		},
+		"fn l10n_disabled": {
+			giveContent: "{{ if l10n_disabled }}Y{{ else }}N{{ end }}",
+			giveProps:   tpl.Properties{L10nDisabled: true},
+			wantContent: "Y",
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			content, err := renderer.Render([]byte(tt.giveContent), tt.giveProps)

--- a/templates/app-down.html
+++ b/templates/app-down.html
@@ -225,6 +225,7 @@
         }
     });
 
+    // {{ if l10n_enabled }}
     if (navigator.language.substring(0, 2).toLowerCase() !== 'en') {
         ((s, p) => { // localize the page (details here - https://github.com/tarampampam/error-pages/tree/master/l10n)
             s.src = 'https://cdn.jsdelivr.net/gh/tarampampam/error-pages@2/l10n/l10n.min.js'; // '../l10n/l10n.js';
@@ -233,6 +234,7 @@
             p.appendChild(s);
         })(document.createElement('script'), document.body);
     }
+    // {{ end }}
 </script>
 </body>
 <!--

--- a/templates/cats.html
+++ b/templates/cats.html
@@ -104,6 +104,7 @@
     </div>
 </div>
 <script>
+    // {{ if l10n_enabled }}
     if (navigator.language.substring(0, 2).toLowerCase() !== 'en') {
         ((s, p) => { // localize the page (details here - https://github.com/tarampampam/error-pages/tree/master/l10n)
             s.src = 'https://cdn.jsdelivr.net/gh/tarampampam/error-pages@2/l10n/l10n.min.js'; // '../l10n/l10n.js';
@@ -112,6 +113,7 @@
             p.appendChild(s);
         })(document.createElement('script'), document.body);
     }
+    // {{ end }}
 </script>
 </body>
 <!--

--- a/templates/connection.html
+++ b/templates/connection.html
@@ -254,6 +254,7 @@
         console.warn('Cannot parse the error code:', errorCode);
     }
 
+    // {{ if l10n_enabled }}
     if (navigator.language.substring(0, 2).toLowerCase() !== 'en') {
         ((s, p) => { // localize the page (details here - https://github.com/tarampampam/error-pages/tree/master/l10n)
             s.src = 'https://cdn.jsdelivr.net/gh/tarampampam/error-pages@2/l10n/l10n.min.js'; // '../l10n/l10n.js';
@@ -262,6 +263,7 @@
             p.appendChild(s);
         })(document.createElement('script'), document.body);
     }
+    // {{ end }}
 </script>
 <!--
     Error {{ code }}: {{ message }}

--- a/templates/ghost.html
+++ b/templates/ghost.html
@@ -98,6 +98,7 @@
     </div>
 </div>
 <script>
+    // {{ if l10n_enabled }}
     if (navigator.language.substring(0, 2).toLowerCase() !== 'en') {
         ((s, p) => { // localize the page (details here - https://github.com/tarampampam/error-pages/tree/master/l10n)
             s.src = 'https://cdn.jsdelivr.net/gh/tarampampam/error-pages@2/l10n/l10n.min.js'; // '../l10n/l10n.js';
@@ -106,6 +107,7 @@
             p.appendChild(s);
         })(document.createElement('script'), document.body);
     }
+    // {{ end }}
 </script>
 </body>
 <!--

--- a/templates/hacker-terminal.html
+++ b/templates/hacker-terminal.html
@@ -163,6 +163,7 @@
     {{ end }}
 </div>
 <script>
+    // {{ if l10n_enabled }}
     if (navigator.language.substring(0, 2).toLowerCase() !== 'en') {
         ((s, p) => { // localize the page (details here - https://github.com/tarampampam/error-pages/tree/master/l10n)
             s.src = 'https://cdn.jsdelivr.net/gh/tarampampam/error-pages@2/l10n/l10n.min.js'; // '../l10n/l10n.js';
@@ -171,6 +172,7 @@
             p.appendChild(s);
         })(document.createElement('script'), document.body);
     }
+    // {{ end }}
 </script>
 </body>
 <!--

--- a/templates/l7-dark.html
+++ b/templates/l7-dark.html
@@ -82,6 +82,7 @@
     </div>
 </div>
 <script>
+    // {{ if l10n_enabled }}
     if (navigator.language.substring(0, 2).toLowerCase() !== 'en') {
         ((s, p) => { // localize the page (details here - https://github.com/tarampampam/error-pages/tree/master/l10n)
             s.src = 'https://cdn.jsdelivr.net/gh/tarampampam/error-pages@2/l10n/l10n.min.js'; // '../l10n/l10n.js';
@@ -90,6 +91,7 @@
             p.appendChild(s);
         })(document.createElement('script'), document.body);
     }
+    // {{ end }}
 </script>
 </body>
 <!--

--- a/templates/l7-light.html
+++ b/templates/l7-light.html
@@ -84,6 +84,7 @@
     </div>
 </div>
 <script>
+    // {{ if l10n_enabled }}
     if (navigator.language.substring(0, 2).toLowerCase() !== 'en') {
         ((s, p) => { // localize the page (details here - https://github.com/tarampampam/error-pages/tree/master/l10n)
             s.src = 'https://cdn.jsdelivr.net/gh/tarampampam/error-pages@2/l10n/l10n.min.js'; // '../l10n/l10n.js';
@@ -92,6 +93,7 @@
             p.appendChild(s);
         })(document.createElement('script'), document.body);
     }
+    // {{ end }}
 </script>
 </body>
 <!--

--- a/templates/lost-in-space.html
+++ b/templates/lost-in-space.html
@@ -378,6 +378,7 @@
         console.warn('gsap library is not initialized (network error?)')
     }
 
+    // {{ if l10n_enabled }}
     if (navigator.language.substring(0, 2).toLowerCase() !== 'en') {
         ((s, p) => { // localize the page (details here - https://github.com/tarampampam/error-pages/tree/master/l10n)
             s.src = 'https://cdn.jsdelivr.net/gh/tarampampam/error-pages@2/l10n/l10n.min.js'; // '../l10n/l10n.js';
@@ -386,6 +387,7 @@
             p.appendChild(s);
         })(document.createElement('script'), document.body);
     }
+    // {{ end }}
 </script>
 
 </body>

--- a/templates/matrix.html
+++ b/templates/matrix.html
@@ -262,6 +262,7 @@
 
     (new Matrix(document.getElementById('matrix'))).run(document.getElementById('matrix-words'));
 
+    // {{ if l10n_enabled }}
     if (navigator.language.substring(0, 2).toLowerCase() !== 'en') {
         ((s, p) => { // localize the page (details here - https://github.com/tarampampam/error-pages/tree/master/l10n)
             s.src = 'https://cdn.jsdelivr.net/gh/tarampampam/error-pages@2/l10n/l10n.min.js'; // '../l10n/l10n.js';
@@ -270,6 +271,7 @@
             p.appendChild(s);
         })(document.createElement('script'), document.body);
     }
+    // {{ end }}
 </script>
 </body>
 <!--

--- a/templates/noise.html
+++ b/templates/noise.html
@@ -175,6 +175,7 @@
         window.clearInterval(flickerInterval);
     });
 
+    // {{ if l10n_enabled }}
     if (navigator.language.substring(0, 2).toLowerCase() !== 'en') {
         ((s, p) => { // localize the page (details here - https://github.com/tarampampam/error-pages/tree/master/l10n)
             s.src = 'https://cdn.jsdelivr.net/gh/tarampampam/error-pages@2/l10n/l10n.min.js'; // '../l10n/l10n.js';
@@ -183,6 +184,7 @@
             p.appendChild(s);
         })(document.createElement('script'), document.body);
     }
+    // {{ end }}
 </script>
 </body>
 <!--

--- a/templates/readme.md
+++ b/templates/readme.md
@@ -10,24 +10,26 @@ Creating templates is a very simple operation, even for those who know nothing a
 
 ### Error page & request data
 
-| Signature                           | Description                                                   | Example                                      |
-|-------------------------------------|---------------------------------------------------------------|----------------------------------------------|
-| `{{ code }}`                        | Error page code                                               | `404`                                        |
-| `{{ message }}`                     | Error code message                                            | `Not found`                                  |
-| `{{ description }}`                 | Error code description                                        | `The server can not find the requested page` |
-| `{{ original_uri }}`                | `X-Original-URI` header value                                 | `/foo1/bar2`                                 |
-| `{{ namespace }}`                   | `X-Namespace` header value                                    | `foo`                                        |
-| `{{ ingress_name }}`                | `X-Ingress-Name` header value                                 | `bar`                                        |
-| `{{ service_name }}`                | `X-Service-Name` header value                                 | `baz`                                        |
-| `{{ service_port }}`                | `X-Service-Port` header value                                 | `8080`                                       |
-| `{{ request_id }}`                  | `X-Request-ID` header value                                   | `12AB34CD56EF78`                             |
-| `{{ forwarded_for }}`               | `X-Forwarded-For` header value                                | `203.0.113.195, 70.41.3.18`                  |
-| `{{ host }}`                        | `Host` header value                                           | `example.com`                                |
-| `{{ now.Unix }}`                    | Current timestamp (e.g. in Unix format)                       | `1643621927`                                 |
-| `{{ hostname }}`                    | OS hostname                                                   | `ab12cd34ef56`                               |
-| `{{ version }}`                     | Application version                                           | `2.5.0`                                      |
-| `{{ if show_details }}...{{ end }}` | Logical operator (server started with "show details" option?) |                                              |
-| `{{ if hide_details }}...{{ end }}` | Same as above, but inverted                                   |                                              |
+| Signature                            | Description                                                   | Example                                      |
+|--------------------------------------|---------------------------------------------------------------|----------------------------------------------|
+| `{{ code }}`                         | Error page code                                               | `404`                                        |
+| `{{ message }}`                      | Error code message                                            | `Not found`                                  |
+| `{{ description }}`                  | Error code description                                        | `The server can not find the requested page` |
+| `{{ original_uri }}`                 | `X-Original-URI` header value                                 | `/foo1/bar2`                                 |
+| `{{ namespace }}`                    | `X-Namespace` header value                                    | `foo`                                        |
+| `{{ ingress_name }}`                 | `X-Ingress-Name` header value                                 | `bar`                                        |
+| `{{ service_name }}`                 | `X-Service-Name` header value                                 | `baz`                                        |
+| `{{ service_port }}`                 | `X-Service-Port` header value                                 | `8080`                                       |
+| `{{ request_id }}`                   | `X-Request-ID` header value                                   | `12AB34CD56EF78`                             |
+| `{{ forwarded_for }}`                | `X-Forwarded-For` header value                                | `203.0.113.195, 70.41.3.18`                  |
+| `{{ host }}`                         | `Host` header value                                           | `example.com`                                |
+| `{{ now.Unix }}`                     | Current timestamp (e.g. in Unix format)                       | `1643621927`                                 |
+| `{{ hostname }}`                     | OS hostname                                                   | `ab12cd34ef56`                               |
+| `{{ version }}`                      | Application version                                           | `2.5.0`                                      |
+| `{{ if show_details }}...{{ end }}`  | Logical operator (server started with "show details" option?) |                                              |
+| `{{ if hide_details }}...{{ end }}`  | Same as above, but inverted                                   |                                              |
+| `{{ if l10n_enabled }}...{{ end }}`  | Logical operator (l10n is enabled?)                           |                                              |
+| `{{ if l10n_disabled }}...{{ end }}` | Same as above, but inverted                                   |                                              |
 
 ### Modifiers
 

--- a/templates/shuffle.html
+++ b/templates/shuffle.html
@@ -215,6 +215,7 @@
     }, 550);
     // {{ end }}
 
+    // {{ if l10n_enabled }}
     if (navigator.language.substring(0, 2).toLowerCase() !== 'en') {
         ((s, p) => { // localize the page (details here - https://github.com/tarampampam/error-pages/tree/master/l10n)
             s.src = 'https://cdn.jsdelivr.net/gh/tarampampam/error-pages@2/l10n/l10n.min.js'; // '../l10n/l10n.js';
@@ -223,6 +224,7 @@
             p.appendChild(s);
         })(document.createElement('script'), document.body);
     }
+    // {{ end }}
 </script>
 </body>
 <!--


### PR DESCRIPTION
## Description

### Added

- Possibility to disable error pages auto-localization (using `--disable-l10n` flag for the `serve` & `build` commands or environment variable `DISABLE_L10N`)

Fixes #91

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
