### PR TITLE
Add catch all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v2.20.0
+
+### Added
+- Added possibility catch all paths with error page 404 (using `--catch-all` flag for the `serve` or environment variable `CATCH_ALL=true`)
+
+### Changed
+- Enabled prom go collectors
+
+### Fixed
+- Not working test (internal/metrics/metrics_test.go)
+- Removed mixed handling methods on both value and pointer receivers (internal/cli/serve/flags.go)
+
 ## v2.19.0
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -39,3 +39,5 @@ require (
 	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
+
+replace github.com/tarampampam/error-pages => github.com/chrisamti/error-pages v1.8.1-0.20221202060955-6a6809b07ff9

--- a/go.mod
+++ b/go.mod
@@ -39,5 +39,3 @@ require (
 	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
-
-replace github.com/tarampampam/error-pages => github.com/chrisamti/error-pages v1.8.1-0.20221202060955-6a6809b07ff9

--- a/internal/cli/serve/command.go
+++ b/internal/cli/serve/command.go
@@ -7,11 +7,12 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+
 	"github.com/tarampampam/error-pages/internal/breaker"
 	"github.com/tarampampam/error-pages/internal/config"
 	appHttp "github.com/tarampampam/error-pages/internal/http"
 	"github.com/tarampampam/error-pages/internal/pick"
-	"go.uber.org/zap"
 )
 
 // NewCommand creates `serve` command.
@@ -130,6 +131,7 @@ func run(parentCtx context.Context, log *zap.Logger, cfg *config.Config, f flags
 			zap.Uint16("default HTTP response code", opt.Default.HTTPCode),
 			zap.Strings("proxy headers", opt.ProxyHTTPHeaders),
 			zap.Bool("show request details", opt.ShowDetails),
+			zap.Bool("catch all pages", opt.CatchAll),
 			zap.Bool("localization disabled", opt.L10n.Disabled),
 		)
 

--- a/internal/cli/serve/flags.go
+++ b/internal/cli/serve/flags.go
@@ -52,7 +52,7 @@ const (
 	useRandomTemplateHourly        = "random-hourly"
 )
 
-func (f *flags) Init(flagSet *pflag.FlagSet) {
+func (f *flags) Init(flagSet *pflag.FlagSet) { //nolint:funlen
 	flagSet.StringVarP(
 		&f.Listen.IP,
 		listenFlagName, "l",
@@ -117,7 +117,7 @@ func (f *flags) Init(flagSet *pflag.FlagSet) {
 	)
 }
 
-func (f *flags) OverrideUsingEnv(flagSet *pflag.FlagSet) (lastErr error) { //nolint:gocognit,gocyclo
+func (f *flags) OverrideUsingEnv(flagSet *pflag.FlagSet) (lastErr error) { //nolint:gocognit,gocyclo,funlen
 	flagSet.VisitAll(func(flag *pflag.Flag) {
 		// flag was NOT defined using CLI (flags should have maximal priority)
 		if !flag.Changed { //nolint:nestif
@@ -168,8 +168,10 @@ func (f *flags) OverrideUsingEnv(flagSet *pflag.FlagSet) (lastErr error) { //nol
 				}
 
 			case catchAll:
-				if _, exists := env.CatchAll.Lookup(); exists {
-					f.catchAllPages = true
+				if envVar, exists := env.CatchAll.Lookup(); exists {
+					if b, err := strconv.ParseBool(envVar); err == nil {
+						f.catchAllPages = b
+					}
 				}
 
 			case disableL10nFlagName:

--- a/internal/cli/serve/flags.go
+++ b/internal/cli/serve/flags.go
@@ -26,8 +26,11 @@ type flags struct {
 	}
 	defaultErrorPage string
 	defaultHTTPCode  uint16
+	catchAllPages    bool
 	showDetails      bool
+
 	proxyHTTPHeaders string // comma-separated
+
 }
 
 const (
@@ -36,6 +39,7 @@ const (
 	templateNameFlagName     = "template-name"
 	defaultErrorPageFlagName = "default-error-page"
 	defaultHTTPCodeFlagName  = "default-http-code"
+	catchAll                 = "catch-all"
 	showDetailsFlagName      = "show-details"
 	proxyHTTPHeadersFlagName = "proxy-headers"
 	disableL10nFlagName      = "disable-l10n"
@@ -86,6 +90,12 @@ func (f *flags) Init(flagSet *pflag.FlagSet) {
 		defaultHTTPCodeFlagName, "",
 		404, //nolint:gomnd
 		fmt.Sprintf("default HTTP response code [$%s]", env.DefaultHTTPCode),
+	)
+	flagSet.BoolVarP(
+		&f.catchAllPages,
+		catchAll, "",
+		false,
+		fmt.Sprintf("catch all pages with default http code [$%s]", env.CatchAll),
 	)
 	flagSet.BoolVarP(
 		&f.showDetails,
@@ -155,6 +165,11 @@ func (f *flags) OverrideUsingEnv(flagSet *pflag.FlagSet) (lastErr error) { //nol
 			case proxyHTTPHeadersFlagName:
 				if envVar, exists := env.ProxyHTTPHeaders.Lookup(); exists {
 					f.proxyHTTPHeaders = strings.TrimSpace(envVar)
+				}
+
+			case catchAll:
+				if _, exists := env.CatchAll.Lookup(); exists {
+					f.catchAllPages = true
 				}
 
 			case disableL10nFlagName:
@@ -230,6 +245,7 @@ func (f *flags) ToOptions() (o options.ErrorPage) {
 	o.L10n.Disabled = f.l10n.disabled
 	o.Template.Name = f.template.name
 	o.ShowDetails = f.showDetails
+	o.CatchAll = f.catchAllPages
 	o.ProxyHTTPHeaders = f.headersToProxy()
 
 	return o

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,10 +61,10 @@ type Template struct {
 }
 
 // Name returns the name of the template.
-func (t Template) Name() string { return t.name }
+func (t *Template) Name() string { return t.name }
 
 // Content returns the template content.
-func (t Template) Content() []byte { return t.content }
+func (t *Template) Content() []byte { return t.content }
 
 func (t *Template) loadContentFromFile(filePath string) (err error) {
 	if t.content, err = os.ReadFile(filePath); err != nil {
@@ -121,7 +121,7 @@ type config struct {
 }
 
 // Validate the config struct and return an error if something is wrong.
-func (c config) Validate() error {
+func (c *config) Validate() error {
 	if len(c.Templates) == 0 {
 		return errors.New("empty templates list")
 	} else {

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -15,6 +15,7 @@ const (
 	ShowDetails      envVariable = "SHOW_DETAILS"       // show request details in response
 	ProxyHTTPHeaders envVariable = "PROXY_HTTP_HEADERS" // proxy HTTP request headers list (request -> response)
 	DisableL10n      envVariable = "DISABLE_L10N"       // disable pages localization
+	CatchAll         envVariable = "CATCH_ALL"          // enable catch all mode
 )
 
 // String returns environment variable name in the string representation.

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -16,12 +16,13 @@ const (
 	ProxyHTTPHeaders envVariable = "PROXY_HTTP_HEADERS" // proxy HTTP request headers list (request -> response)
 	DisableL10n      envVariable = "DISABLE_L10N"       // disable pages localization
 	CatchAll         envVariable = "CATCH_ALL"          // enable catch all mode
+	RetryAfter       envVariable = "RETRY_AFTER"
 )
 
 // String returns environment variable name in the string representation.
 func (e envVariable) String() string { return string(e) }
 
 // Lookup retrieves the value of the environment variable. If the variable is present in the environment the value
-// (which may be empty) is returned and the boolean is true. Otherwise the returned value will be empty and the
+// (which may be empty) is returned and the boolean is true. Otherwise, the returned value will be empty and the
 // boolean will be false.
 func (e envVariable) Lookup() (string, bool) { return os.LookupEnv(string(e)) }

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -17,6 +17,7 @@ func TestConstants(t *testing.T) {
 	assert.Equal(t, "SHOW_DETAILS", string(ShowDetails))
 	assert.Equal(t, "PROXY_HTTP_HEADERS", string(ProxyHTTPHeaders))
 	assert.Equal(t, "DISABLE_L10N", string(DisableL10n))
+	assert.Equal(t, "CATCH_ALL", string(CatchAll))
 }
 
 func TestEnvVariable_Lookup(t *testing.T) {
@@ -32,6 +33,7 @@ func TestEnvVariable_Lookup(t *testing.T) {
 		{giveEnv: ShowDetails},
 		{giveEnv: ProxyHTTPHeaders},
 		{giveEnv: DisableL10n},
+		{giveEnv: CatchAll},
 	}
 
 	for _, tt := range cases {

--- a/internal/http/core/errorpage.go
+++ b/internal/http/core/errorpage.go
@@ -1,12 +1,14 @@
 package core
 
 import (
+	"fmt"
 	"strconv"
+
+	"github.com/valyala/fasthttp"
 
 	"github.com/tarampampam/error-pages/internal/config"
 	"github.com/tarampampam/error-pages/internal/options"
 	"github.com/tarampampam/error-pages/internal/tpl"
-	"github.com/valyala/fasthttp"
 )
 
 type templatePicker interface {
@@ -28,6 +30,13 @@ func RespondWithErrorPage( //nolint:funlen,gocyclo
 	opt options.ErrorPage,
 ) {
 	ctx.Response.Header.Set("X-Robots-Tag", "noindex") // block Search indexing
+
+	if opt.RetryAfter > 0 {
+		switch httpCode {
+		case fasthttp.StatusTooManyRequests, fasthttp.StatusServiceUnavailable:
+			ctx.Response.Header.Set("Retry-After", fmt.Sprintf("%d", opt.RetryAfter))
+		}
+	}
 
 	var (
 		clientWant    = ClientWantFormat(ctx)

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -5,6 +5,9 @@ import (
 	"time"
 
 	"github.com/fasthttp/router"
+	"github.com/valyala/fasthttp"
+	"go.uber.org/zap"
+
 	"github.com/tarampampam/error-pages/internal/checkers"
 	"github.com/tarampampam/error-pages/internal/config"
 	"github.com/tarampampam/error-pages/internal/http/common"
@@ -18,8 +21,6 @@ import (
 	"github.com/tarampampam/error-pages/internal/options"
 	"github.com/tarampampam/error-pages/internal/tpl"
 	"github.com/tarampampam/error-pages/internal/version"
-	"github.com/valyala/fasthttp"
-	"go.uber.org/zap"
 )
 
 type Server struct {
@@ -87,7 +88,11 @@ func (s *Server) Register(cfg *config.Config, templatePicker templatePicker, opt
 
 	s.router.GET("/metrics", metricsHandler.NewHandler(reg))
 
-	s.router.NotFound = notfoundHandler.NewHandler()
+	if opt.CatchAll {
+		s.router.NotFound = indexHandler.NewHandler(cfg, templatePicker, s.rdr, opt)
+	} else {
+		s.router.NotFound = notfoundHandler.NewHandler()
+	}
 
 	return nil
 }

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -88,9 +88,11 @@ func (s *Server) Register(cfg *config.Config, templatePicker templatePicker, opt
 
 	s.router.GET("/metrics", metricsHandler.NewHandler(reg))
 
+	// use index handler to catch all paths? Uses DEFAULT_ERROR_PAGE
 	if opt.CatchAll {
 		s.router.NotFound = indexHandler.NewHandler(cfg, templatePicker, s.rdr, opt)
 	} else {
+		// use default not found handler
 		s.router.NotFound = notfoundHandler.NewHandler()
 	}
 

--- a/internal/metrics/registry.go
+++ b/internal/metrics/registry.go
@@ -12,7 +12,7 @@ func NewRegistry() *prometheus.Registry {
 
 	// register common metric collectors
 	registry.MustRegister(
-		// collectors.NewGoCollector(),
+		collectors.NewGoCollector(),
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 	)
 

--- a/internal/metrics/registry_test.go
+++ b/internal/metrics/registry_test.go
@@ -5,13 +5,18 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
+
 	"github.com/tarampampam/error-pages/internal/metrics"
 )
 
 func TestNewRegistry(t *testing.T) {
-	registry := metrics.NewRegistry()
+	reg, m := metrics.NewRegistry(), metrics.NewMetrics()
 
-	count, err := testutil.GatherAndCount(registry)
+	if err := m.Register(reg); err != nil {
+		t.Fatal(err)
+	}
+
+	count, err := testutil.GatherAndCount(reg)
 
 	assert.NoError(t, err)
 	assert.True(t, count >= 6, "not enough common metrics")

--- a/internal/options/errorpage.go
+++ b/internal/options/errorpage.go
@@ -12,5 +12,6 @@ type ErrorPage struct {
 		Name string // template name
 	}
 	ShowDetails      bool     // show request details in response
+	CatchAll         bool     // catch every page with default http code and selected error page template
 	ProxyHTTPHeaders []string // proxy HTTP request headers list
 }

--- a/internal/options/errorpage.go
+++ b/internal/options/errorpage.go
@@ -11,7 +11,13 @@ type ErrorPage struct {
 	Template struct {
 		Name string // template name
 	}
-	ShowDetails      bool     // show request details in response
-	CatchAll         bool     // catch every page with default http code and selected error page template
-	ProxyHTTPHeaders []string // proxy HTTP request headers list
+	ShowDetails bool // show request details in response.
+	CatchAll    bool // catch every page with default http code and selected error page template.
+
+	// RetryAfter (default 30) and only used if http code is 429 or 503.
+	// Adds http header Retry-After: <delay-seconds>.
+	RetryAfter uint16
+
+	// proxy HTTP request headers list.
+	ProxyHTTPHeaders []string
 }


### PR DESCRIPTION
## Description

I need a "catch all paths" version of error-pages for my k8s project in order to show a custom error-page, 
while updating a nextcloud deployment to a higher version.

This is done by creating a temp maintenance deployment and service running error-pages pods. 
As soon as the maintenance pods are up and running, the ingress is being patched to this temp maintenance service. 
After the ingress has been patched to maintenance deployment, any path to the maintenance service should be answered with an error 494 page. 

After the update is done the ingress is restored to the nextcloud service and the maintenance deployment and service will be deleted. Using a traefik middleware did not help in my case. So I decided to add the catch all mode. 

I hope this simple addition is good enough to become a part of the error-pages project. 

Fixes # (issue)
Nothing
## Checklist

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x ] I have commented on my code, particularly in hard-to-understand areas
- [x ] I wrote unit tests for my code _(if tests are required for my changes)_ <!-- feel free to drop this item from the list -->
- [x ] I have made changes in the `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `Added` / `Changed` / `Fixed` sections
* Add a reference to the related issue or this PR `[#123](https://github.com/.../.../(issues|pull)/123)`

-->
