### PR TITLE
New template `orient` added

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -154,6 +154,7 @@ jobs: # Docs: <https://git.io/JvxXE>
           test -f ./out/app-down/404.html
           test -f ./out/connection/404.html
           test -f ./out/matrix/404.html
+          test -f ./out/orient/404.html
 
   docker-image:
     name: Build docker image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 [#190]:https://github.com/tarampampam/error-pages/pull/190
 
-
 ## v2.22.0
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v2.23.0
+
+### Added
+
+- Template `orient` [#190]
+
+[#190]:https://github.com/tarampampam/error-pages/pull/190
+
+
 ## v2.22.0
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Transfer/sec:    140.23MB
 |    `app-down`     |           [![app-down][app-down-screen]][app-down-link]            |
 |   `connection`    |        [![connection][connection-screen]][connection-link]         |
 |     `matrix`      |              [![matrix][matrix-screen]][matrix-link]               |
+|     `orient`      |              [![orient][orient-screen]][orient-link]               |
 
 > Note: `noise` template highly uses the CPU, be careful
 
@@ -148,6 +149,8 @@ Transfer/sec:    140.23MB
 [connection-link]:https://tarampampam.github.io/error-pages/connection/404.html
 [matrix-screen]:https://hsto.org/webt/ng/tf/oi/ngtfoiolvmq6hf15kimcxmhprhk.gif
 [matrix-link]:https://tarampampam.github.io/error-pages/matrix/404.html
+[orient-screen]:https://hsto.org/webt/pz/eu/v_/pzeuv_lyeqr0xpusa4zfrtgk7sa.png
+[orient-link]:https://tarampampam.github.io/error-pages/orient/404.html
 
 ## 🦾 Contributors
 

--- a/error-pages.yml
+++ b/error-pages.yml
@@ -15,6 +15,7 @@ templates:
   - path: ./templates/app-down.html
   - path: ./templates/connection.html
   - path: ./templates/matrix.html
+  - path: ./templates/orient.html
 
 formats:
   json:

--- a/templates/orient.html
+++ b/templates/orient.html
@@ -1,0 +1,518 @@
+<!DOCTYPE html>
+<!--
+    Error {{ code }}: {{ message }}
+    Description: {{ description }}
+-->
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow"/>
+    <link href="https://fonts.googleapis.com/css?family=Nunito&display=swap" rel="stylesheet" type="text/css">
+    <title>{{ message }}</title>
+    <style>
+        html {
+            line-height: 1.15;
+            -ms-text-size-adjust: 100%;
+            -webkit-text-size-adjust: 100%;
+        }
+
+        body {
+            margin: 0;
+        }
+
+        header,
+        nav,
+        section {
+            display: block;
+        }
+
+        figcaption,
+        main {
+            display: block;
+        }
+
+        a {
+            background-color: transparent;
+            -webkit-text-decoration-skip: objects;
+        }
+
+        strong {
+            font-weight: inherit;
+        }
+
+        strong {
+            font-weight: bolder;
+        }
+
+        code {
+            font-family: monospace, monospace;
+            font-size: 1em;
+        }
+
+        dfn {
+            font-style: italic;
+        }
+
+        svg:not(:root) {
+            overflow: hidden;
+        }
+
+        button,
+        input {
+            font-family: sans-serif;
+            font-size: 100%;
+            line-height: 1.15;
+            margin: 0;
+        }
+
+        button,
+        input {
+            overflow: visible;
+        }
+
+        button {
+            text-transform: none;
+        }
+
+        button,
+        html [type="button"],
+        [type="reset"],
+        [type="submit"] {
+            -webkit-appearance: button;
+        }
+
+        button::-moz-focus-inner,
+        [type="button"]::-moz-focus-inner,
+        [type="reset"]::-moz-focus-inner,
+        [type="submit"]::-moz-focus-inner {
+            border-style: none;
+            padding: 0;
+        }
+
+        button:-moz-focusring,
+        [type="button"]:-moz-focusring,
+        [type="reset"]:-moz-focusring,
+        [type="submit"]:-moz-focusring {
+            outline: 1px dotted ButtonText;
+        }
+
+        legend {
+            -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+            color: inherit;
+            display: table;
+            max-width: 100%;
+            padding: 0;
+            white-space: normal;
+        }
+
+        [type="checkbox"],
+        [type="radio"] {
+            -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+            padding: 0;
+        }
+
+        [type="number"]::-webkit-inner-spin-button,
+        [type="number"]::-webkit-outer-spin-button {
+            height: auto;
+        }
+
+        [type="search"] {
+            -webkit-appearance: textfield;
+            outline-offset: -2px;
+        }
+
+        [type="search"]::-webkit-search-cancel-button,
+        [type="search"]::-webkit-search-decoration {
+            -webkit-appearance: none;
+        }
+
+        ::-webkit-file-upload-button {
+            -webkit-appearance: button;
+            font: inherit;
+        }
+
+        menu {
+            display: block;
+        }
+
+        canvas {
+            display: inline-block;
+        }
+
+        template {
+            display: none;
+        }
+
+        [hidden] {
+            display: none;
+        }
+
+        html {
+            -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+            font-family: sans-serif;
+        }
+
+        *,
+        *::before,
+        *::after {
+            -webkit-box-sizing: inherit;
+            box-sizing: inherit;
+        }
+
+        p {
+            margin: 0;
+        }
+
+        button {
+            background: transparent;
+            padding: 0;
+        }
+
+        button:focus {
+            outline: 1px dotted;
+            outline: 5px auto -webkit-focus-ring-color;
+        }
+
+        *,
+        *::before,
+        *::after {
+            border-width: 0;
+            border-style: solid;
+            border-color: #dae1e7;
+        }
+
+        button,
+        [type="button"],
+        [type="reset"],
+        [type="submit"] {
+            border-radius: 0;
+        }
+
+        button,
+        input {
+            font-family: inherit;
+        }
+
+        input::-webkit-input-placeholder {
+            color: inherit;
+            opacity: .5;
+        }
+
+        input:-ms-input-placeholder {
+            color: inherit;
+            opacity: .5;
+        }
+
+        input::-ms-input-placeholder {
+            color: inherit;
+            opacity: .5;
+        }
+
+        input::placeholder {
+            color: inherit;
+            opacity: .5;
+        }
+
+        button,
+        [role=button] {
+            cursor: pointer;
+        }
+
+        .bg-transparent {
+            background-color: transparent;
+        }
+
+        .bg-white {
+            background-color: #fff;
+        }
+
+        .bg-teal-light {
+            background-color: #64d5ca;
+        }
+
+        .bg-blue-dark {
+            background-color: #2779bd;
+        }
+
+        .bg-indigo-light {
+            background-color: #7886d7;
+        }
+
+        .bg-purple-light {
+            background-color: #a779e9;
+        }
+
+        .bg-no-repeat {
+            background-repeat: no-repeat;
+        }
+
+        .bg-cover {
+            background-size: cover;
+        }
+
+        .border-grey-light {
+            border-color: #dae1e7;
+        }
+
+        .hover\:border-grey:hover {
+            border-color: #b8c2cc;
+        }
+
+        .rounded-lg {
+            border-radius: .5rem;
+        }
+
+        .border-2 {
+            border-width: 2px;
+        }
+
+        .hidden {
+            display: none;
+        }
+
+        .flex {
+            display: -webkit-box;
+            display: -ms-flexbox;
+            display: flex;
+        }
+
+        .items-center {
+            -webkit-box-align: center;
+            -ms-flex-align: center;
+            align-items: center;
+        }
+
+        .justify-center {
+            -webkit-box-pack: center;
+            -ms-flex-pack: center;
+            justify-content: center;
+        }
+
+        .font-sans {
+            font-family: Nunito, sans-serif;
+        }
+
+        .font-light {
+            font-weight: 300;
+        }
+
+        .font-bold {
+            font-weight: 700;
+        }
+
+        .font-black {
+            font-weight: 900;
+        }
+
+        .h-1 {
+            height: .25rem;
+        }
+
+        .leading-normal {
+            line-height: 1.5;
+        }
+
+        .m-8 {
+            margin: 2rem;
+        }
+
+        .my-3 {
+            margin-top: .75rem;
+            margin-bottom: .75rem;
+        }
+
+        .mb-8 {
+            margin-bottom: 2rem;
+        }
+
+        .max-w-sm {
+            max-width: 30rem;
+        }
+
+        .min-h-screen {
+            min-height: 100vh;
+        }
+
+        .py-3 {
+            padding-top: .75rem;
+            padding-bottom: .75rem;
+        }
+
+        .px-6 {
+            padding-left: 1.5rem;
+            padding-right: 1.5rem;
+        }
+
+        .pb-full {
+            padding-bottom: 100%;
+        }
+
+        .absolute {
+            position: absolute;
+        }
+
+        .relative {
+            position: relative;
+        }
+
+        .pin {
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
+        }
+
+        .text-black {
+            color: #22292f;
+        }
+
+        .text-grey-darkest {
+            color: #3d4852;
+        }
+
+        .text-grey-darker {
+            color: #606f7b;
+        }
+
+        .text-2xl {
+            font-size: 1.5rem;
+        }
+
+        .text-5xl {
+            font-size: 3rem;
+        }
+
+        .uppercase {
+            text-transform: uppercase;
+        }
+
+        .antialiased {
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+        }
+
+        .tracking-wide {
+            letter-spacing: .05em;
+        }
+
+        .w-16 {
+            width: 4rem;
+        }
+
+        .w-full {
+            width: 100%;
+        }
+
+        @media (min-width: 768px) {
+            .md\:bg-left {
+                background-position: left;
+            }
+
+            .md\:bg-right {
+                background-position: right;
+            }
+
+            .md\:flex {
+                display: -webkit-box;
+                display: -ms-flexbox;
+                display: flex;
+            }
+
+            .md\:my-6 {
+                margin-top: 1.5rem;
+                margin-bottom: 1.5rem;
+            }
+
+            .md\:min-h-screen {
+                min-height: 100vh;
+            }
+
+            .md\:pb-0 {
+                padding-bottom: 0;
+            }
+
+            .md\:text-3xl {
+                font-size: 1.875rem;
+            }
+
+            .md\:text-15xl {
+                font-size: 9rem;
+            }
+
+            .md\:w-1\/2 {
+                width: 50%;
+            }
+        }
+
+        @media (min-width: 992px) {
+            .lg\:bg-center {
+                background-position: center;
+            }
+        }
+
+        .bg-morning {
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 1024 1024'%3E%3Cdefs%3E%3ClinearGradient id='a' x1='50.31%25' x2='50%25' y1='74.74%25' y2='0%25'%3E%3Cstop offset='0%25' stop-color='%23E26B6B'/%3E%3Cstop offset='50.28%25' stop-color='%23F5BCF4'/%3E%3Cstop offset='100%25' stop-color='%238690E1'/%3E%3C/linearGradient%3E%3ClinearGradient id='b' x1='50%25' x2='50%25' y1='0%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%238C9CE7'/%3E%3Cstop offset='100%25' stop-color='%234353A4'/%3E%3C/linearGradient%3E%3ClinearGradient id='c' x1='50%25' x2='50%25' y1='0%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%23D1D9FF'/%3E%3Cstop offset='100%25' stop-color='%238395EB'/%3E%3C/linearGradient%3E%3Ccircle id='e' cx='622' cy='663' r='60'/%3E%3Cfilter id='d' width='260%25' height='260%25' x='-80%25' y='-80%25' filterUnits='objectBoundingBox'%3E%3CfeOffset in='SourceAlpha' result='shadowOffsetOuter1'/%3E%3CfeGaussianBlur in='shadowOffsetOuter1' result='shadowBlurOuter1' stdDeviation='32'/%3E%3CfeColorMatrix in='shadowBlurOuter1' values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0'/%3E%3C/filter%3E%3ClinearGradient id='f' x1='49.87%25' x2='49.87%25' y1='3.62%25' y2='77.75%25'%3E%3Cstop offset='0%25' stop-color='%23B0DDF1'/%3E%3Cstop offset='100%25' stop-color='%23325C82'/%3E%3C/linearGradient%3E%3ClinearGradient id='g' x1='100%25' x2='72.45%25' y1='0%25' y2='85.2%25'%3E%3Cstop offset='0%25' stop-color='%231D3A6D'/%3E%3Cstop offset='100%25' stop-color='%23467994'/%3E%3C/linearGradient%3E%3ClinearGradient id='h' x1='49.48%25' x2='49.87%25' y1='11.66%25' y2='77.75%25'%3E%3Cstop offset='0%25' stop-color='%23B9C9F7'/%3E%3Cstop offset='100%25' stop-color='%23301863'/%3E%3C/linearGradient%3E%3ClinearGradient id='i' x1='91.59%25' x2='70.98%25' y1='5.89%25' y2='88%25'%3E%3Cstop offset='0%25' stop-color='%232D3173'/%3E%3Cstop offset='100%25' stop-color='%237F90E0'/%3E%3C/linearGradient%3E%3ClinearGradient id='j' x1='70.98%25' x2='70.98%25' y1='9.88%25' y2='88%25'%3E%3Cstop offset='0%25' stop-color='%232D3173'/%3E%3Cstop offset='100%25' stop-color='%237F90E0'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Crect width='1024' height='1024' fill='url(%23a)'/%3E%3Cg transform='translate(211 420)'%3E%3Cpath fill='%238C9CE7' d='M65 0a2 2 0 0 1 2 2v23h-4V2c0-1.1.9-2 2-2z'/%3E%3Cpath fill='%235263B8' d='M64 24h2a3 3 0 0 1 3 3v2h-8v-2a3 3 0 0 1 3-3z'/%3E%3Cpath fill='url(%23b)' d='M65 108h40V68a40 40 0 1 0-80 0v40h40z'/%3E%3Cpolygon fill='%232E3D87' points='0 118 30 112 30 218 0 218'/%3E%3Cpolygon fill='%23301862' points='60 118 30 112 30 218 60 218'/%3E%3Cpath fill='url(%23c)' d='M45 107V68a40.02 40.02 0 0 1 30.03-38.75C92.27 33.65 105 49.11 105 67.5V107H45z'/%3E%3Cpolygon fill='%234353A4' points='15 78 65 68 67 70 67 178 15 178'/%3E%3Cpolygon fill='%238C9CE7' points='115 78 65 68 65 70 65 178 115 178'/%3E%3Cpolygon fill='%234353A4' points='75 118 105 112 105 218 75 218'/%3E%3Cpolygon fill='%238C9CE7' points='135 118 105 112 105 218 135 218'/%3E%3C/g%3E%3Cuse fill='black' filter='url(%23d)' xlink:href='%23e'/%3E%3Cuse fill='%23FFFFFF' xlink:href='%23e'/%3E%3Cg transform='translate(146 245)'%3E%3Cpath fill='url(%23f)' d='M169.12 450.57C192.22 464.04 143.85 532.52 24 656h649C328.94 514.3 160.98 445.83 169.12 450.57z'/%3E%3Cpath fill='url(%23g)' d='M178.5 538.5C137.83 567.17 199.67 606.33 364 656H0l178.5-117.5z'/%3E%3C/g%3E%3Cg transform='translate(0 255)'%3E%3Cpath fill='url(%23h)' d='M1024 685H0V400.08C77.3 366.4 155.26 330 297.4 330c250 0 250.76 125.25 500 125 84.03-.08 160.02-18.2 226.6-40.93V685z'/%3E%3C/g%3E%3Cpath fill='%231F2A68' d='M251 506a8 8 0 0 1 8 8v15l-16 1v-16a8 8 0 0 1 8-8z'/%3E%3Cpath fill='%237C8CDA' d='M253 506.25a8 8 0 0 0-6 7.75v15.75l-4 .25v-16a8 8 0 0 1 10-7.75z'/%3E%3Cpath fill='%231F2A68' d='M251 546a8 8 0 0 1 8 8v15l-16 1v-16a8 8 0 0 1 8-8z'/%3E%3Cpath fill='%237C8CDA' d='M253 546.25a8 8 0 0 0-6 7.75v15.75l-4 .25v-16a8 8 0 0 1 10-7.75z'/%3E%3Cpath fill='%235263B8' d='M301 506a8 8 0 0 1 8 8v16l-16-1v-15a8 8 0 0 1 8-8z'/%3E%3Cpath fill='%23293781' d='M305 529.75V514a8 8 0 0 0-6-7.75 8.01 8.01 0 0 1 10 7.75v16l-4-.25z'/%3E%3Cg transform='translate(0 636)'%3E%3Cpath fill='url(%23h)' d='M1024 356H0V185.82c137.51-15.4 203.1-50.49 356.67-60.1C555.24 113.3 606.71.59 856.74.59 929.52.58 981.18 11.2 1024 26.26V356z'/%3E%3Cpath fill='url(%23i)' d='M1024 26.21V326H856.91c99.31-86.5 112.63-140.75 39.97-162.78C710.24 106.64 795.12.58 856.9.58c72.7 0 124.3 10.6 167.09 25.63z'/%3E%3Cpath fill='url(%23i)' d='M1024 199.32V326H857c99.31-86.6 112.63-140.94 39.97-163L1024 199.32z'/%3E%3C/g%3E%3Ccircle cx='566' cy='599' r='110' fill='%23FFFFFF' opacity='.1'/%3E%3Ccircle cx='669' cy='539' r='60' fill='%23FFFFFF' opacity='.1'/%3E%3Cg transform='translate(0 705)'%3E%3Cpath fill='url(%23h)' d='M0 319V68.93C67.12 35.69 129.55 0 263 0c250 0 331.46 162.6 530 175 107.42 6.71 163-26.77 231-58.92V319H0z'/%3E%3Cpath fill='url(%23i)' d='M353.02 319H0V68.93C67.12 35.69 129.55 0 263 0c71.14 0 151.5 12.76 151.5 70.5 0 54.5-45.5 79.72-112.5 109-82.26 35.95-54.57 111.68 51.02 139.5z'/%3E%3Cpath fill='url(%23j)' d='M353.02 319H0v-14.8l302-124.7c-82.26 35.95-54.57 111.68 51.02 139.5z'/%3E%3C/g%3E%3Ccircle cx='414' cy='799' r='70' fill='%23FFFFFF' opacity='.1'/%3E%3Ccircle cx='479' cy='745' r='30' fill='%23FFFFFF' opacity='.1'/%3E%3Cg fill='%23FFFFFF' opacity='.15' transform='translate(49 214)'%3E%3Cpath d='M554.67 131.48a9.46 9.46 0 0 1 13.33 0 9.46 9.46 0 0 0 13.33 0l13.33-13.24a28.39 28.39 0 0 1 40 0l10 9.93a14.2 14.2 0 0 0 20 0 14.2 14.2 0 0 1 20 0l.6.6a31.8 31.8 0 0 1 9.4 22.56H548v-3.84c0-6.01 2.4-11.78 6.67-16.01zM751 8.25c11.07-11 28.93-11 40 0l10 9.94a14.19 14.19 0 0 0 20 0 14.19 14.19 0 0 1 20 0 16.36 16.36 0 0 0 21.3 1.5l8.7-6.47a33.47 33.47 0 0 1 40 0l4.06 3.03A39.6 39.6 0 0 1 931 48H731c0-12.72 8.93-28.75 20-39.75zM14.1 75.14l.9-.9a21.29 21.29 0 0 1 30 0 21.29 21.29 0 0 0 30 0l10-9.93a35.48 35.48 0 0 1 50 0l15 14.9a14.2 14.2 0 0 0 20 0 14.2 14.2 0 0 1 20 0c6.4 6.35 10 15 10 24.02V109H0c0-12.71 5.07-24.9 14.1-33.86z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+        }
+
+        .bg-day {
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 1024 1024'%3E%3Cdefs%3E%3ClinearGradient id='a' x1='50%25' x2='50%25' y1='100%25' y2='0%25'%3E%3Cstop offset='0%25' stop-color='%23F6EDAE'/%3E%3Cstop offset='100%25' stop-color='%2391D4D7'/%3E%3C/linearGradient%3E%3ClinearGradient id='b' x1='49.87%25' x2='49.87%25' y1='3.62%25' y2='77.75%25'%3E%3Cstop offset='0%25' stop-color='%23B0DDF1'/%3E%3Cstop offset='100%25' stop-color='%23325C82'/%3E%3C/linearGradient%3E%3ClinearGradient id='c' x1='100%25' x2='72.45%25' y1='0%25' y2='85.2%25'%3E%3Cstop offset='0%25' stop-color='%231D3A6D'/%3E%3Cstop offset='100%25' stop-color='%23467994'/%3E%3C/linearGradient%3E%3ClinearGradient id='d' x1='54.81%25' x2='50%25' y1='-18.48%25' y2='59.98%25'%3E%3Cstop offset='0%25' stop-color='%23FFFFFF'/%3E%3Cstop offset='28.15%25' stop-color='%23F8E6B3'/%3E%3Cstop offset='100%25' stop-color='%23D5812F'/%3E%3C/linearGradient%3E%3ClinearGradient id='e' x1='52.84%25' x2='49.87%25' y1='2.8%25' y2='77.75%25'%3E%3Cstop offset='0%25' stop-color='%23FFFFFF'/%3E%3Cstop offset='22.15%25' stop-color='%23F8E6B3'/%3E%3Cstop offset='100%25' stop-color='%23F9D989'/%3E%3C/linearGradient%3E%3ClinearGradient id='f' x1='91.59%25' x2='66.97%25' y1='5.89%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%23CE4014'/%3E%3Cstop offset='100%25' stop-color='%23FFD56E'/%3E%3C/linearGradient%3E%3ClinearGradient id='g' x1='40.28%25' x2='66.37%25' y1='30.88%25' y2='108.51%25'%3E%3Cstop offset='0%25' stop-color='%23A2491E'/%3E%3Cstop offset='100%25' stop-color='%23F4B35A'/%3E%3C/linearGradient%3E%3Ccircle id='i' cx='825' cy='235' r='70'/%3E%3Cfilter id='h' width='237.1%25' height='237.1%25' x='-68.6%25' y='-68.6%25' filterUnits='objectBoundingBox'%3E%3CfeOffset in='SourceAlpha' result='shadowOffsetOuter1'/%3E%3CfeGaussianBlur in='shadowOffsetOuter1' result='shadowBlurOuter1' stdDeviation='32'/%3E%3CfeColorMatrix in='shadowBlurOuter1' values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0'/%3E%3C/filter%3E%3ClinearGradient id='j' x1='50%25' x2='50%25' y1='0%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%23B29959'/%3E%3Cstop offset='100%25' stop-color='%23CEAD5B'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Crect width='1024' height='1024' fill='url(%23a)'/%3E%3Cpath fill='%23FFFFFF' d='M1024 378.13v39.37H790a71.59 71.59 0 0 1 21.14-50.8l1.36-1.34a31.93 31.93 0 0 1 45 0 31.93 31.93 0 0 0 45 0l15-14.9a53.21 53.21 0 0 1 75 0l22.5 22.35a21.2 21.2 0 0 0 9 5.32z' opacity='.15'/%3E%3Cg transform='translate(26 245)'%3E%3Cpath fill='url(%23b)' d='M289.12 450.57C312.22 464.04 263.85 532.52 144 656h649C448.94 514.3 280.98 445.83 289.12 450.57z'/%3E%3Cpath fill='url(%23c)' d='M262.5 402c-48 50 147.33 58.02 36 136.5-40.67 28.67 21.17 67.83 185.5 117.5H0l262.5-254z'/%3E%3Cpath fill='url(%23c)' d='M298.5 538.5C257.83 567.17 319.67 606.33 484 656H120l178.5-117.5z'/%3E%3C/g%3E%3Cpath fill='%23134F4E' d='M783 593.73a29.95 29.95 0 0 1-12-24c0-9.8 4.72-18.52 12-24-5.02 6.69-8 15-8 24 0 9.01 2.98 17.32 8 24z'/%3E%3Cg fill='%23134F4E' transform='matrix(-1 0 0 1 876 532)'%3E%3Cpath d='M24 66.73a29.95 29.95 0 0 1-12-24c0-9.8 4.72-18.52 12-24-5.02 6.69-8 15-8 24 0 9.01 2.98 17.32 8 24z'/%3E%3Cpath d='M36 22.4l-3.96-3.98a5 5 0 0 0-6.5-.5 3 3 0 0 1 3.7-3.55l8.7 2.33a8 8 0 0 1 5.66 9.8l-1-1.73a2 2 0 0 0-1.21-.93L36 22.4zm-5.38-2.56L37 26.2a8 8 0 0 1 0 11.32v-2a2 2 0 0 0-.6-1.42L26.39 24.08a3 3 0 0 1 4.24-4.24zM14.21 9.8l-3.94-3.94a2 2 0 0 0-1.42-.59h-2a8 8 0 0 1 11.32 0l6.36 6.37a3 3 0 0 1-1.22 4.98 5 5 0 0 0-3.68-5.37l-5.42-1.45zm4.9 3.39a3 3 0 1 1-1.55 5.8L3.87 15.31a2 2 0 0 0-1.52.2l-1.73 1a8 8 0 0 1 9.8-5.65l8.7 2.33z'/%3E%3C/g%3E%3Cg transform='translate(0 245)'%3E%3Cpath fill='url(%23d)' d='M1024 423.16V645H58.09c-32.12-75.17-32.12-123.84 0-146 48.17-33.24 127.17-64.25 293.33-64 166.17.25 246.67-105 413.33-105 117.33 0 183.93 55.8 259.25 93.16z'/%3E%3Cpath fill='url(%23e)' d='M1024 778H0V398.62C75.53 363.05 136.43 320 283 320c111.86 0 358.86 69.82 741 209.47V778z'/%3E%3Cpath fill='url(%23f)' d='M0 778V398.62C75.53 363.05 136.43 320 283 320c71.14 0 85.96 26.04 32.5 82-79.5 83.22 279.7 2.01 336 131.5 26 59.8-69.83 141.3-287.48 244.5H0z'/%3E%3Cpath fill='url(%23g)' d='M364.02 778H0V638.4L315.5 402c-79.5 83.22 279.7 2.01 336 131.5 26 59.8-69.83 141.3-287.48 244.5z'/%3E%3C/g%3E%3Cpath fill='%23134F4E' d='M795 549.4l-3.96-3.98a5 5 0 0 0-6.5-.5 3 3 0 0 1 3.7-3.55l8.7 2.33a8 8 0 0 1 5.66 9.8l-1-1.73a2 2 0 0 0-1.21-.93L795 549.4zm-5.38-2.56l6.37 6.36a8 8 0 0 1 0 11.32v-2a2 2 0 0 0-.6-1.42l-10.01-10.02a3 3 0 0 1 4.24-4.24zm-16.41-10.03l-3.94-3.94a2 2 0 0 0-1.42-.59h-2a8 8 0 0 1 11.32 0l6.36 6.37a3 3 0 0 1-1.22 4.98 5 5 0 0 0-3.68-5.37l-5.42-1.45zm4.9 3.39a3 3 0 1 1-1.55 5.8l-13.69-3.68a2 2 0 0 0-1.52.2l-1.73 1a8 8 0 0 1 9.8-5.65l8.7 2.33z'/%3E%3Cpath fill='%23FFFFFF' d='M395.67 116.48a9.46 9.46 0 0 1 13.33 0 9.46 9.46 0 0 0 13.33 0l13.33-13.24a28.39 28.39 0 0 1 40 0l10 9.93a14.2 14.2 0 0 0 20 0 14.2 14.2 0 0 1 20 0l.6.6a31.8 31.8 0 0 1 9.4 22.56H389v-3.84c0-6.01 2.4-11.78 6.67-16.01zM98.1 249.1l5.9-5.86c11.07-11 28.93-11 40 0l10 9.94a14.19 14.19 0 0 0 20 0 14.19 14.19 0 0 1 20 0 16.36 16.36 0 0 0 21.3 1.5l8.7-6.47a33.47 33.47 0 0 1 40 0l4.06 3.03A39.6 39.6 0 0 1 284 283H84a47.77 47.77 0 0 1 14.1-33.89z' opacity='.15'/%3E%3Cuse fill='black' filter='url(%23h)' xlink:href='%23i'/%3E%3Cuse fill='%23FFFFFF' xlink:href='%23i'/%3E%3Cpath fill='%23FFFFFF' d='M702.69 960.64a4.32 4.32 0 0 1-1.04 6.87c-2.26 1.2-3.69 2.1-4.27 2.67-.51.52-1.17 1.4-1.97 2.62a3.53 3.53 0 0 1-5.45.56 3.53 3.53 0 0 1 .56-5.44c1.23-.8 2.1-1.46 2.62-1.98.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.88-1.03z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M700.32 962a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25a3.53 3.53 0 0 1-3.45 4.25 3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9a4.32 4.32 0 0 1 4.13-5.6z' transform='rotate(45 700.323 971)'/%3E%3Cg transform='rotate(-15 3943.802 -2244.376)'%3E%3Cpath fill='%23FFFFFF' d='M16.65 3.9a4.32 4.32 0 0 1-1.03 6.87c-2.27 1.2-3.7 2.1-4.27 2.67-.52.52-1.18 1.4-1.98 2.62a3.53 3.53 0 0 1-5.44.56 3.53 3.53 0 0 1 .56-5.44c1.23-.8 2.1-1.46 2.62-1.98.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.87-1.03z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M13.32 5a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 13.32 23a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 13.32 5z' transform='rotate(45 13.323 14)'/%3E%3C/g%3E%3Cg transform='rotate(-15 4117.1 -2152.014)'%3E%3Cpath fill='%23FFFFFF' d='M16.65 3.9a4.32 4.32 0 0 1-1.03 6.87c-2.27 1.2-3.7 2.1-4.27 2.67-.52.52-1.18 1.4-1.98 2.62a3.53 3.53 0 0 1-5.44.56 3.53 3.53 0 0 1 .56-5.44c1.23-.8 2.1-1.46 2.62-1.98.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.87-1.03z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M13.32 5a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 13.32 23a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 13.32 5z' transform='rotate(45 13.323 14)'/%3E%3C/g%3E%3Cg transform='rotate(-15 4127.186 -2023.184)'%3E%3Cpath fill='%23FFFFFF' d='M16.65 3.9a4.32 4.32 0 0 1-1.03 6.87c-2.27 1.2-3.7 2.1-4.27 2.67-.52.52-1.18 1.4-1.98 2.62a3.53 3.53 0 0 1-5.44.56 3.53 3.53 0 0 1 .56-5.44c1.23-.8 2.1-1.46 2.62-1.98.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.87-1.03z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M13.32 5a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 13.32 23a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 13.32 5z' transform='rotate(45 13.323 14)'/%3E%3C/g%3E%3Cg transform='rotate(-30 2055.753 -866.842)'%3E%3Cpath fill='%23FFFFFF' d='M16.55 3.4a4.32 4.32 0 0 1-1.03 6.88c-2.27 1.2-3.7 2.1-4.27 2.67-.52.52-1.18 1.39-1.98 2.62a3.53 3.53 0 0 1-5.44.56 3.53 3.53 0 0 1 .56-5.44c1.23-.8 2.1-1.46 2.62-1.98.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.87-1.04z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M12.32 6a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 12.32 24a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 12.32 6z' transform='rotate(45 12.323 15)'/%3E%3C/g%3E%3Cg transform='rotate(-30 2046.995 -931.189)'%3E%3Cpath fill='%23FFFFFF' d='M16.55 3.4a4.32 4.32 0 0 1-1.03 6.88c-2.27 1.2-3.7 2.1-4.27 2.67-.52.52-1.18 1.39-1.98 2.62a3.53 3.53 0 0 1-5.44.56 3.53 3.53 0 0 1 .56-5.44c1.23-.8 2.1-1.46 2.62-1.98.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.87-1.04z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M12.32 6a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 12.32 24a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 12.32 6z' transform='rotate(45 12.323 15)'/%3E%3C/g%3E%3Cg transform='rotate(-45 1406.147 -409.132)'%3E%3Cpath fill='%23FFFFFF' d='M16.93 3.22a4.32 4.32 0 0 1-1.03 6.88c-2.27 1.2-3.7 2.09-4.27 2.67-.52.52-1.18 1.39-1.98 2.61a3.53 3.53 0 0 1-5.45.57 3.53 3.53 0 0 1 .57-5.45c1.22-.8 2.1-1.46 2.61-1.97.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.88-1.04z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M10.32 6a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 10.32 24a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 10.32 6z' transform='rotate(45 10.323 15)'/%3E%3C/g%3E%3Cg transform='rotate(-24 2389.63 -1296.285)'%3E%3Cpath fill='%23FFFFFF' d='M16.93 3.22a4.32 4.32 0 0 1-1.03 6.88c-2.27 1.2-3.7 2.09-4.27 2.67-.52.52-1.18 1.39-1.98 2.61a3.53 3.53 0 0 1-5.45.57 3.53 3.53 0 0 1 .57-5.45c1.22-.8 2.1-1.46 2.61-1.97.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.88-1.04z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M10.32 6a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 10.32 24a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 10.32 6z' transform='rotate(45 10.323 15)'/%3E%3C/g%3E%3Cg transform='rotate(-50 1258.425 -353.155)'%3E%3Cpath fill='%23FFFFFF' d='M16.93 3.22a4.32 4.32 0 0 1-1.03 6.88c-2.27 1.2-3.7 2.09-4.27 2.67-.52.52-1.18 1.39-1.98 2.61a3.53 3.53 0 0 1-5.45.57 3.53 3.53 0 0 1 .57-5.45c1.22-.8 2.1-1.46 2.61-1.97.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.88-1.04z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M10.32 6a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 10.32 24a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 10.32 6z' transform='rotate(45 10.323 15)'/%3E%3C/g%3E%3Cg transform='rotate(-35 1652.744 -777.703)'%3E%3Cpath fill='%23FFFFFF' d='M16.08 3.06a4.1 4.1 0 0 1-.98 6.53c-2.15 1.14-3.5 1.99-4.05 2.54-.5.5-1.12 1.32-1.88 2.49a3.35 3.35 0 0 1-5.18.53 3.35 3.35 0 0 1 .54-5.17c1.16-.76 2-1.39 2.48-1.88.55-.55 1.4-1.9 2.54-4.06a4.1 4.1 0 0 1 6.53-.98z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M9.8 5.7a4.1 4.1 0 0 1 3.93 5.31c-.71 2.33-1.07 3.89-1.07 4.67 0 .69.14 1.72.43 3.08A3.35 3.35 0 0 1 9.8 22.8a3.35 3.35 0 0 1-3.28-4.04c.28-1.36.43-2.39.43-3.09 0-.77-.36-2.33-1.08-4.66A4.1 4.1 0 0 1 9.81 5.7z' transform='rotate(45 9.807 14.25)'/%3E%3C/g%3E%3Cg transform='rotate(-35 1605.77 -758.112)'%3E%3Cpath fill='%23FFFFFF' d='M15.24 2.9a3.89 3.89 0 0 1-.93 6.19c-2.04 1.08-3.33 1.88-3.85 2.4a15.6 15.6 0 0 0-1.78 2.36 3.17 3.17 0 0 1-4.9.5 3.17 3.17 0 0 1 .51-4.9 15.6 15.6 0 0 0 2.36-1.78c.52-.52 1.32-1.8 2.4-3.84a3.89 3.89 0 0 1 6.19-.93z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M9.3 5.4a3.89 3.89 0 0 1 3.7 5.03c-.67 2.21-1 3.68-1 4.42 0 .66.13 1.63.4 2.92a3.17 3.17 0 0 1-3.1 3.83 3.17 3.17 0 0 1-3.12-3.83c.28-1.29.41-2.26.41-2.92 0-.74-.34-2.2-1.02-4.42A3.89 3.89 0 0 1 9.3 5.4z' transform='rotate(45 9.29 13.5)'/%3E%3C/g%3E%3Cg transform='rotate(-35 1591.812 -807.843)'%3E%3Cpath fill='%23FFFFFF' d='M15.24 2.9a3.89 3.89 0 0 1-.93 6.19c-2.04 1.08-3.33 1.88-3.85 2.4a15.6 15.6 0 0 0-1.78 2.36 3.17 3.17 0 0 1-4.9.5 3.17 3.17 0 0 1 .51-4.9 15.6 15.6 0 0 0 2.36-1.78c.52-.52 1.32-1.8 2.4-3.84a3.89 3.89 0 0 1 6.19-.93z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M9.3 5.4a3.89 3.89 0 0 1 3.7 5.03c-.67 2.21-1 3.68-1 4.42 0 .66.13 1.63.4 2.92a3.17 3.17 0 0 1-3.1 3.83 3.17 3.17 0 0 1-3.12-3.83c.28-1.29.41-2.26.41-2.92 0-.74-.34-2.2-1.02-4.42A3.89 3.89 0 0 1 9.3 5.4z' transform='rotate(45 9.29 13.5)'/%3E%3C/g%3E%3Cg transform='rotate(-44 1287.793 -536.004)'%3E%3Cpath fill='%23FFFFFF' d='M15.24 2.9a3.89 3.89 0 0 1-.93 6.19c-2.04 1.08-3.33 1.88-3.85 2.4a15.6 15.6 0 0 0-1.78 2.36 3.17 3.17 0 0 1-4.9.5 3.17 3.17 0 0 1 .51-4.9 15.6 15.6 0 0 0 2.36-1.78c.52-.52 1.32-1.8 2.4-3.84a3.89 3.89 0 0 1 6.19-.93z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M9.3 5.4a3.89 3.89 0 0 1 3.7 5.03c-.67 2.21-1 3.68-1 4.42 0 .66.13 1.63.4 2.92a3.17 3.17 0 0 1-3.1 3.83 3.17 3.17 0 0 1-3.12-3.83c.28-1.29.41-2.26.41-2.92 0-.74-.34-2.2-1.02-4.42A3.89 3.89 0 0 1 9.3 5.4z' transform='rotate(45 9.29 13.5)'/%3E%3C/g%3E%3Cg transform='rotate(-28 1831.874 -1151.097)'%3E%3Cpath fill='%23FFFFFF' d='M15.24 2.9a3.89 3.89 0 0 1-.93 6.19c-2.04 1.08-3.33 1.88-3.85 2.4a15.6 15.6 0 0 0-1.78 2.36 3.17 3.17 0 0 1-4.9.5 3.17 3.17 0 0 1 .51-4.9 15.6 15.6 0 0 0 2.36-1.78c.52-.52 1.32-1.8 2.4-3.84a3.89 3.89 0 0 1 6.19-.93z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M9.3 5.4a3.89 3.89 0 0 1 3.7 5.03c-.67 2.21-1 3.68-1 4.42 0 .66.13 1.63.4 2.92a3.17 3.17 0 0 1-3.1 3.83 3.17 3.17 0 0 1-3.12-3.83c.28-1.29.41-2.26.41-2.92 0-.74-.34-2.2-1.02-4.42A3.89 3.89 0 0 1 9.3 5.4z' transform='rotate(45 9.29 13.5)'/%3E%3C/g%3E%3Cg transform='rotate(-41 1316.639 -621.138)'%3E%3Cpath fill='%23FFFFFF' d='M13.54 2.58a3.46 3.46 0 0 1-.82 5.5A17.18 17.18 0 0 0 9.3 10.2c-.41.42-.94 1.12-1.58 2.1a2.82 2.82 0 0 1-4.36.45 2.82 2.82 0 0 1 .45-4.36c.99-.64 1.68-1.17 2.1-1.58.46-.46 1.17-1.6 2.13-3.42a3.46 3.46 0 0 1 5.5-.82z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M8.26 4.8a3.46 3.46 0 0 1 3.3 4.47c-.6 1.97-.9 3.27-.9 3.93 0 .59.12 1.45.36 2.6a2.82 2.82 0 0 1-2.76 3.4 2.82 2.82 0 0 1-2.76-3.4c.24-1.15.36-2.01.36-2.6 0-.66-.3-1.96-.9-3.93a3.46 3.46 0 0 1 3.3-4.47z' transform='rotate(45 8.258 12)'/%3E%3C/g%3E%3Cg transform='rotate(-41 1286.706 -646.924)'%3E%3Cpath fill='%23FFFFFF' d='M11.85 2.26a3.03 3.03 0 0 1-.72 4.8 15.04 15.04 0 0 0-3 1.88c-.35.36-.82.97-1.38 1.83a2.47 2.47 0 0 1-3.8.4 2.47 2.47 0 0 1 .39-3.82C4.2 6.8 4.8 6.33 5.17 5.97c.4-.4 1.03-1.4 1.87-3a3.03 3.03 0 0 1 4.81-.71z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M7.23 4.2a3.03 3.03 0 0 1 2.89 3.91c-.53 1.72-.8 2.87-.8 3.44 0 .51.11 1.27.32 2.27a2.47 2.47 0 0 1-2.41 2.98 2.47 2.47 0 0 1-2.42-2.98c.21-1 .32-1.76.32-2.27 0-.57-.27-1.72-.8-3.44a3.03 3.03 0 0 1 2.9-3.91z' transform='rotate(45 7.226 10.5)'/%3E%3C/g%3E%3Cg transform='rotate(-24 2011.85 -1427.831)'%3E%3Cpath fill='%23FFFFFF' d='M13.54 2.58a3.46 3.46 0 0 1-.82 5.5A17.18 17.18 0 0 0 9.3 10.2c-.41.42-.94 1.12-1.58 2.1a2.82 2.82 0 0 1-4.36.45 2.82 2.82 0 0 1 .45-4.36c.99-.64 1.68-1.17 2.1-1.58.46-.46 1.17-1.6 2.13-3.42a3.46 3.46 0 0 1 5.5-.82z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M8.26 4.8a3.46 3.46 0 0 1 3.3 4.47c-.6 1.97-.9 3.27-.9 3.93 0 .59.12 1.45.36 2.6a2.82 2.82 0 0 1-2.76 3.4 2.82 2.82 0 0 1-2.76-3.4c.24-1.15.36-2.01.36-2.6 0-.66-.3-1.96-.9-3.93a3.46 3.46 0 0 1 3.3-4.47z' transform='rotate(45 8.258 12)'/%3E%3C/g%3E%3Ccircle cx='756' cy='209' r='110' fill='%23FFFFFF' opacity='.2'/%3E%3Ccircle cx='859' cy='139' r='40' fill='%23FFFFFF' opacity='.2'/%3E%3Ccircle cx='551' cy='383' r='70' fill='%23FFFFFF' opacity='.2'/%3E%3Ccircle cx='666' cy='359' r='30' fill='%23FFFFFF' opacity='.2'/%3E%3Crect width='60' height='6' x='722' y='547' fill='%23FFFFFF' opacity='.4' rx='3'/%3E%3Crect width='60' height='6' x='842' y='565' fill='%23FFFFFF' opacity='.4' rx='3'/%3E%3Crect width='40' height='6' x='762' y='559' fill='%23FFFFFF' opacity='.4' rx='3'/%3E%3Crect width='40' height='6' x='872' y='553' fill='%23FFFFFF' opacity='.4' rx='3'/%3E%3Crect width='40' height='6' x='811' y='547' fill='%23FFFFFF' opacity='.4' rx='3'/%3E%3C/g%3E%3C/svg%3E");
+        }
+
+        .bg-evening {
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 1024 1024'%3E%3Cdefs%3E%3ClinearGradient id='a' x1='50.31%25' x2='50%25' y1='74.74%25' y2='0%25'%3E%3Cstop offset='0%25' stop-color='%23FFE98A'/%3E%3Cstop offset='67.7%25' stop-color='%23B63E59'/%3E%3Cstop offset='100%25' stop-color='%2368126F'/%3E%3C/linearGradient%3E%3Ccircle id='c' cx='603' cy='682' r='93'/%3E%3Cfilter id='b' width='203.2%25' height='203.2%25' x='-51.6%25' y='-51.6%25' filterUnits='objectBoundingBox'%3E%3CfeOffset in='SourceAlpha' result='shadowOffsetOuter1'/%3E%3CfeGaussianBlur in='shadowOffsetOuter1' result='shadowBlurOuter1' stdDeviation='32'/%3E%3CfeColorMatrix in='shadowBlurOuter1' values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0'/%3E%3C/filter%3E%3ClinearGradient id='d' x1='49.48%25' x2='49.87%25' y1='11.66%25' y2='77.75%25'%3E%3Cstop offset='0%25' stop-color='%23F7EAB9'/%3E%3Cstop offset='100%25' stop-color='%23E5765E'/%3E%3C/linearGradient%3E%3ClinearGradient id='e' x1='91.59%25' x2='66.97%25' y1='5.89%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%23A22A50'/%3E%3Cstop offset='100%25' stop-color='%23EE7566'/%3E%3C/linearGradient%3E%3ClinearGradient id='f' x1='49.48%25' x2='49.61%25' y1='11.66%25' y2='98.34%25'%3E%3Cstop offset='0%25' stop-color='%23F7EAB9'/%3E%3Cstop offset='100%25' stop-color='%23E5765E'/%3E%3C/linearGradient%3E%3ClinearGradient id='g' x1='78.5%25' x2='36.4%25' y1='106.76%25' y2='26.41%25'%3E%3Cstop offset='0%25' stop-color='%23A22A50'/%3E%3Cstop offset='100%25' stop-color='%23EE7566'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Crect width='1024' height='1024' fill='url(%23a)'/%3E%3Cuse fill='black' filter='url(%23b)' xlink:href='%23c'/%3E%3Cuse fill='%23FFF6CB' xlink:href='%23c'/%3E%3Cg fill='%23FFFFFF' opacity='.3' transform='translate(14 23)'%3E%3Ccircle cx='203' cy='255' r='3' fill-opacity='.4'/%3E%3Ccircle cx='82' cy='234' r='2'/%3E%3Ccircle cx='22' cy='264' r='2' opacity='.4'/%3E%3Ccircle cx='113' cy='65' r='3'/%3E%3Ccircle cx='202' cy='2' r='2'/%3E%3Ccircle cx='2' cy='114' r='2'/%3E%3Ccircle cx='152' cy='144' r='2'/%3E%3Ccircle cx='362' cy='224' r='2'/%3E%3Ccircle cx='453' cy='65' r='3' opacity='.4'/%3E%3Ccircle cx='513' cy='255' r='3'/%3E%3Ccircle cx='593' cy='115' r='3'/%3E%3Ccircle cx='803' cy='5' r='3' opacity='.4'/%3E%3Ccircle cx='502' cy='134' r='2'/%3E%3Ccircle cx='832' cy='204' r='2'/%3E%3Ccircle cx='752' cy='114' r='2'/%3E%3Ccircle cx='933' cy='255' r='3' opacity='.4'/%3E%3Ccircle cx='703' cy='225' r='3'/%3E%3Ccircle cx='903' cy='55' r='3'/%3E%3Ccircle cx='982' cy='144' r='2'/%3E%3Ccircle cx='632' cy='14' r='2'/%3E%3C/g%3E%3Cg transform='translate(0 550)'%3E%3Cpath fill='%238E2C15' d='M259 5.47c0 5.33 3.33 9.5 10 12.5s9.67 9.16 9 18.5h1c.67-6.31 1-11.8 1-16.47 8.67 0 13.33-1.33 14-4 .67 4.98 1.67 8.3 3 9.97 1.33 1.66 2 5.16 2 10.5h1c0-5.65.33-9.64 1-11.97 1-3.5 4-10.03-1-14.53S295 7 290 3c-5-4-10-3-13 2s-5 7-9 7-5-3.53-5-5.53c0-2 2-5-1.5-5s-7.5 0-7.5 2c0 1.33 1.67 2 5 2z'/%3E%3Cpath fill='url(%23d)' d='M1024 390H0V105.08C77.3 71.4 155.26 35 297.4 35c250 0 250.76 125.25 500 125 84.03-.08 160.02-18.2 226.6-40.93V390z'/%3E%3Cpath fill='url(%23d)' d='M1024 442H0V271.82c137.51-15.4 203.1-50.49 356.67-60.1C555.24 199.3 606.71 86.59 856.74 86.59c72.78 0 124.44 10.62 167.26 25.68V442z'/%3E%3Cpath fill='url(%23e)' d='M1024 112.21V412H856.91c99.31-86.5 112.63-140.75 39.97-162.78C710.24 192.64 795.12 86.58 856.9 86.58c72.7 0 124.3 10.6 167.09 25.63z'/%3E%3Cpath fill='url(%23e)' d='M1024 285.32V412H857c99.31-86.6 112.63-140.94 39.97-163L1024 285.32z'/%3E%3Cpath fill='url(%23f)' d='M0 474V223.93C67.12 190.69 129.55 155 263 155c250 0 331.46 162.6 530 175 107.42 6.71 163-26.77 231-58.92V474H0z'/%3E%3Cpath fill='url(%23e)' d='M353.02 474H0V223.93C67.12 190.69 129.55 155 263 155c71.14 0 151.5 12.76 151.5 70.5 0 54.5-45.5 79.72-112.5 109-82.26 35.95-54.57 111.68 51.02 139.5z'/%3E%3Cpath fill='url(%23g)' d='M353.02 474H0v-14.8l302-124.7c-82.26 35.95-54.57 111.68 51.02 139.5z'/%3E%3C/g%3E%3Cg fill='%23FFFFFF' opacity='.2' transform='translate(288 523)'%3E%3Ccircle cx='250' cy='110' r='110'/%3E%3Ccircle cx='420' cy='78' r='60'/%3E%3Ccircle cx='70' cy='220' r='70'/%3E%3C/g%3E%3Cg fill='%23FFFFFF' fill-rule='nonzero' opacity='.08' transform='translate(135 316)'%3E%3Cpath d='M10 80.22a14.2 14.2 0 0 1 20 0 14.2 14.2 0 0 0 20 0l20-19.86a42.58 42.58 0 0 1 60 0l15 14.9a21.3 21.3 0 0 0 30 0 21.3 21.3 0 0 1 30 0l.9.9A47.69 47.69 0 0 1 220 110H0v-5.76c0-9.02 3.6-17.67 10-24.02zm559.1-66.11l5.9-5.86c11.07-11 28.93-11 40 0l10 9.94a14.19 14.19 0 0 0 20 0 14.19 14.19 0 0 1 20 0 16.36 16.36 0 0 0 21.3 1.5l8.7-6.47a33.47 33.47 0 0 1 40 0l4.06 3.03A39.6 39.6 0 0 1 755 48H555a47.77 47.77 0 0 1 14.1-33.89z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+        }
+
+        .bg-night {
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 1024 1024'%3E%3Cdefs%3E%3ClinearGradient id='a' x1='50%25' x2='50%25' y1='100%25' y2='0%25'%3E%3Cstop offset='0%25' stop-color='%2376C3C3'/%3E%3Cstop offset='100%25' stop-color='%23183468'/%3E%3C/linearGradient%3E%3ClinearGradient id='b' x1='100%25' x2='0%25' y1='50%25' y2='50%25'%3E%3Cstop offset='0%25' stop-color='%23486587'/%3E%3Cstop offset='33.23%25' stop-color='%23183352'/%3E%3Cstop offset='66.67%25' stop-color='%23264A6E'/%3E%3Cstop offset='100%25' stop-color='%23183352'/%3E%3C/linearGradient%3E%3ClinearGradient id='c' x1='49.87%25' x2='48.5%25' y1='3.62%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%23E0F2FA'/%3E%3Cstop offset='8.98%25' stop-color='%2389BED6'/%3E%3Cstop offset='32.98%25' stop-color='%231E3C6E'/%3E%3Cstop offset='100%25' stop-color='%231B376B'/%3E%3C/linearGradient%3E%3ClinearGradient id='d' x1='49.87%25' x2='49.87%25' y1='3.62%25' y2='77.75%25'%3E%3Cstop offset='0%25' stop-color='%23B0DDF1'/%3E%3Cstop offset='100%25' stop-color='%23325C82'/%3E%3C/linearGradient%3E%3ClinearGradient id='e' x1='91.59%25' x2='66.97%25' y1='5.89%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%231D3A6D'/%3E%3Cstop offset='100%25' stop-color='%23467994'/%3E%3C/linearGradient%3E%3ClinearGradient id='f' x1='97.27%25' x2='52.53%25' y1='6.88%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%231D3A6D'/%3E%3Cstop offset='100%25' stop-color='%23467994'/%3E%3C/linearGradient%3E%3ClinearGradient id='g' x1='82.73%25' x2='41.46%25' y1='41.06%25' y2='167.23%25'%3E%3Cstop offset='0%25' stop-color='%231D3A6D'/%3E%3Cstop offset='100%25' stop-color='%23467994'/%3E%3C/linearGradient%3E%3ClinearGradient id='h' x1='49.87%25' x2='49.87%25' y1='3.62%25' y2='100.77%25'%3E%3Cstop offset='0%25' stop-color='%23B0DDF1'/%3E%3Cstop offset='100%25' stop-color='%23325C82'/%3E%3C/linearGradient%3E%3ClinearGradient id='i' x1='100%25' x2='72.45%25' y1='0%25' y2='85.2%25'%3E%3Cstop offset='0%25' stop-color='%231D3A6D'/%3E%3Cstop offset='100%25' stop-color='%23467994'/%3E%3C/linearGradient%3E%3ClinearGradient id='j' x1='100%25' x2='62.1%25' y1='0%25' y2='68.86%25'%3E%3Cstop offset='0%25' stop-color='%23163055'/%3E%3Cstop offset='100%25' stop-color='%232F587F'/%3E%3C/linearGradient%3E%3Ccircle id='l' cx='180' cy='102' r='40'/%3E%3Cfilter id='k' width='340%25' height='340%25' x='-120%25' y='-120%25' filterUnits='objectBoundingBox'%3E%3CfeOffset in='SourceAlpha' result='shadowOffsetOuter1'/%3E%3CfeGaussianBlur in='shadowOffsetOuter1' result='shadowBlurOuter1' stdDeviation='32'/%3E%3CfeColorMatrix in='shadowBlurOuter1' values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.696473053 0'/%3E%3C/filter%3E%3ClinearGradient id='m' x1='0%25' y1='50%25' y2='50%25'%3E%3Cstop offset='0%25' stop-color='%23FFFFFF' stop-opacity='0'/%3E%3Cstop offset='100%25' stop-color='%23FFFFFF'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Crect width='1024' height='1024' fill='url(%23a)'/%3E%3Cg transform='translate(761 481)'%3E%3Cpolygon fill='%238DBCD2' points='96 27 100 26 100 37 96 37'/%3E%3Cpolygon fill='%238DBCD2' points='76 23 80 22 80 37 76 37'/%3E%3Cpolygon fill='%23183352' points='40 22 44 23 44 37 40 37'/%3E%3Cpolygon fill='%23183352' points='20 26 24 27 24 41 20 41'/%3E%3Crect width='2' height='20' x='59' fill='%23183352' opacity='.5'/%3E%3Cpath fill='url(%23b)' d='M61 0c3 0 3 2 6 2s3-2 6-2 3 2 6 2v8c-3 0-3-2-6-2s-3 2-6 2-3-2-6-2V0z'/%3E%3Cpath fill='%238DBCD2' d='M50 20l10-2v110H0L10 28l10-2v10.92l10-.98V24l10-2v12.96l10-.98V20z'/%3E%3Cpath fill='%23183352' d='M100 26l10 2 10 100H60V18l10 2v13.98l10 .98V22l10 2v11.94l10 .98V26z'/%3E%3C/g%3E%3Cg transform='translate(0 565)'%3E%3Cpath fill='url(%23c)' d='M1024 385H0V106.86c118.4 21.09 185.14 57.03 327.4 48.14 198.54-12.4 250-125 500-125 90.18 0 147.92 16.3 196.6 37.12V385z'/%3E%3Cpath fill='url(%23d)' d='M1024 355H0V79.56C76.46 43.81 137.14 0 285 0c250 0 301.46 112.6 500 125 103.24 6.45 166.7-10.7 239-28.66V355z'/%3E%3Cpath fill='url(%23d)' d='M344.12 130.57C367.22 144.04 318.85 212.52 199 336h649C503.94 194.3 335.98 125.83 344.12 130.57z'/%3E%3Cpath fill='url(%23e)' d='M0 336V79.56C76.46 43.81 137.14 0 285 0c71.14 0 86.22 26.04 32.5 82-48 50 147.33 58.02 36 136.5-40.67 28.67 21.17 67.83 185.5 117.5H0z'/%3E%3Cpath fill='url(%23f)' d='M317.5 82c-48 50 147.33 58.02 36 136.5-40.67 28.67 21.17 67.83 185.5 117.5H55L317.5 82z'/%3E%3Cpath fill='url(%23g)' d='M353.5 218.5C312.83 247.17 374.67 286.33 539 336H175l178.5-117.5z'/%3E%3Cpath fill='url(%23h)' d='M0 459V264.54c100.25 21.2 167.18 50.29 296.67 42.19 198.57-12.43 250.04-125.15 500.07-125.15 109.75 0 171.47 24.16 227.26 51.25V459H0z'/%3E%3Cpath fill='url(%23i)' d='M1024 459H846.16c51.95-58.9 48.86-97.16-9.28-114.78-186.64-56.58-101.76-162.64-39.97-162.64 109.64 0 171.34 24.12 227.09 51.19V459z'/%3E%3Cpath fill='url(%23j)' d='M1024 459H846.19c52.01-59.01 48.94-97.34-9.22-115L1024 397.48V459z'/%3E%3C/g%3E%3Cg transform='translate(94 23)'%3E%3Cuse fill='black' filter='url(%23k)' xlink:href='%23l'/%3E%3Cuse fill='%23D2F1FE' xlink:href='%23l'/%3E%3Ccircle cx='123' cy='255' r='3' fill='%23FFFFFF' fill-opacity='.4'/%3E%3Ccircle cx='2' cy='234' r='2' fill='%23FFFFFF'/%3E%3Ccircle cx='33' cy='65' r='3' fill='%23FFFFFF'/%3E%3Ccircle cx='122' cy='2' r='2' fill='%23FFFFFF'/%3E%3Ccircle cx='72' cy='144' r='2' fill='%23FFFFFF'/%3E%3Ccircle cx='282' cy='224' r='2' fill='%23FFFFFF'/%3E%3Ccircle cx='373' cy='65' r='3' fill='%23FFFFFF' opacity='.4'/%3E%3Ccircle cx='433' cy='255' r='3' fill='%23FFFFFF'/%3E%3Cpath fill='url(%23m)' d='M373.25 325.25a5 5 0 0 0 0-10h-75v10h75z' opacity='.4' transform='rotate(45 338.251 320.251)'/%3E%3Ccircle cx='363' cy='345' r='3' fill='%23FFFFFF'/%3E%3Ccircle cx='513' cy='115' r='3' fill='%23FFFFFF'/%3E%3Ccircle cx='723' cy='5' r='3' fill='%23FFFFFF' opacity='.4'/%3E%3Ccircle cx='422' cy='134' r='2' fill='%23FFFFFF'/%3E%3Ccircle cx='752' cy='204' r='2' fill='%23FFFFFF'/%3E%3Ccircle cx='672' cy='114' r='2' fill='%23FFFFFF'/%3E%3Ccircle cx='853' cy='255' r='3' fill='%23FFFFFF' opacity='.4'/%3E%3Ccircle cx='623' cy='225' r='3' fill='%23FFFFFF'/%3E%3Ccircle cx='823' cy='55' r='3' fill='%23FFFFFF'/%3E%3Ccircle cx='902' cy='144' r='2' fill='%23FFFFFF'/%3E%3Ccircle cx='552' cy='14' r='2' fill='%23FFFFFF'/%3E%3C/g%3E%3Cpath fill='%23486587' d='M796 535a4 4 0 0 1 4 4v20h-8v-20a4 4 0 0 1 4-4z'/%3E%3Cpath fill='%23071423' d='M798 535.54a4 4 0 0 0-2 3.46v20h-4v-20a4 4 0 0 1 6-3.46zm48-.54a4 4 0 0 1 4 4v20h-8v-20a4 4 0 0 1 4-4z'/%3E%3Cpath fill='%238DBCD2' d='M846 559v-20a4 4 0 0 0-2-3.46 4 4 0 0 1 6 3.46v20h-4z'/%3E%3Cg fill='%23FFFFFF' opacity='.07' transform='translate(54 301)'%3E%3Cpath d='M554.67 131.48a9.46 9.46 0 0 1 13.33 0 9.46 9.46 0 0 0 13.33 0l13.33-13.24a28.39 28.39 0 0 1 40 0l10 9.93a14.2 14.2 0 0 0 20 0 14.2 14.2 0 0 1 20 0l.6.6a31.8 31.8 0 0 1 9.4 22.56H548v-3.84c0-6.01 2.4-11.78 6.67-16.01zM751 8.25c11.07-11 28.93-11 40 0l10 9.94a14.19 14.19 0 0 0 20 0 14.19 14.19 0 0 1 20 0 16.36 16.36 0 0 0 21.3 1.5l8.7-6.47a33.47 33.47 0 0 1 40 0l4.06 3.03A39.6 39.6 0 0 1 931 48H731c0-12.72 8.93-28.75 20-39.75zM14.1 75.14l.9-.9a21.29 21.29 0 0 1 30 0 21.29 21.29 0 0 0 30 0l10-9.93a35.48 35.48 0 0 1 50 0l15 14.9a14.2 14.2 0 0 0 20 0 14.2 14.2 0 0 1 20 0c6.4 6.35 10 15 10 24.02V109H0c0-12.71 5.07-24.9 14.1-33.86z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+        }
+    </style>
+</head>
+<body class="antialiased font-sans">
+    <div class="md:flex min-h-screen">
+        <div class="w-full md:w-1/2 bg-white flex items-center justify-center">
+            <div class="max-w-sm m-8">
+                <div class="text-black text-5xl md:text-15xl font-black">
+                  {{ code }}
+                </div>
+
+                <div class="w-16 h-1 bg-purple-light my-3 md:my-6"></div>
+
+                <p class="text-grey-darker text-2xl md:text-3xl font-light mb-8 leading-normal">
+                  {{ description  }}
+                </p>
+            </div>
+        </div>
+
+        <div class="relative pb-full md:flex md:pb-0 md:min-h-screen w-full md:w-1/2">
+            <div id=bg-canvas class="absolute pin bg-cover bg-no-repeat md:bg-left lg:bg-center">
+            </div>
+        </div>
+    </div>
+
+<script>
+    // set random background
+    var allBackgrounds = ['bg-morning','bg-day','bg-evening', 'bg-night'];
+    var randomBackground = Math.floor(Math.random() * allBackgrounds.length);
+    document.getElementById("bg-canvas").classList.add(allBackgrounds[randomBackground]);
+
+    // {{ if l10n_enabled }}
+    if (navigator.language.substring(0, 2).toLowerCase() !== 'en') {
+        ((s, p) => { // localize the page (details here - https://github.com/tarampampam/error-pages/tree/master/l10n)
+            s.src = 'https://cdn.jsdelivr.net/gh/tarampampam/error-pages@2/l10n/l10n.min.js'; // '../l10n/l10n.js';
+            s.async = s.defer = true;
+            s.addEventListener('load', () => p.removeChild(s));
+            p.appendChild(s);
+        })(document.createElement('script'), document.body);
+    }
+    // {{ end }}
+</script>
+</body>
+<!--
+    Error {{ code }}: {{ message }}
+    Description: {{ description }}
+-->
+</html>

--- a/templates/orient.html
+++ b/templates/orient.html
@@ -5,510 +5,271 @@
 -->
 <html lang="en">
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="robots" content="noindex, nofollow"/>
-    <link href="https://fonts.googleapis.com/css?family=Nunito&display=swap" rel="stylesheet" type="text/css">
-    <title>{{ message }}</title>
-    <style>
-        html {
-            line-height: 1.15;
-            -ms-text-size-adjust: 100%;
-            -webkit-text-size-adjust: 100%;
-        }
-
-        body {
-            margin: 0;
-        }
-
-        header,
-        nav,
-        section {
-            display: block;
-        }
-
-        figcaption,
-        main {
-            display: block;
-        }
-
-        a {
-            background-color: transparent;
-            -webkit-text-decoration-skip: objects;
-        }
-
-        strong {
-            font-weight: inherit;
-        }
-
-        strong {
-            font-weight: bolder;
-        }
-
-        code {
-            font-family: monospace, monospace;
-            font-size: 1em;
-        }
-
-        dfn {
-            font-style: italic;
-        }
-
-        svg:not(:root) {
-            overflow: hidden;
-        }
-
-        button,
-        input {
-            font-family: sans-serif;
-            font-size: 100%;
-            line-height: 1.15;
-            margin: 0;
-        }
-
-        button,
-        input {
-            overflow: visible;
-        }
-
-        button {
-            text-transform: none;
-        }
-
-        button,
-        html [type="button"],
-        [type="reset"],
-        [type="submit"] {
-            -webkit-appearance: button;
-        }
-
-        button::-moz-focus-inner,
-        [type="button"]::-moz-focus-inner,
-        [type="reset"]::-moz-focus-inner,
-        [type="submit"]::-moz-focus-inner {
-            border-style: none;
-            padding: 0;
-        }
-
-        button:-moz-focusring,
-        [type="button"]:-moz-focusring,
-        [type="reset"]:-moz-focusring,
-        [type="submit"]:-moz-focusring {
-            outline: 1px dotted ButtonText;
-        }
-
-        legend {
-            -webkit-box-sizing: border-box;
-            box-sizing: border-box;
-            color: inherit;
-            display: table;
-            max-width: 100%;
-            padding: 0;
-            white-space: normal;
-        }
-
-        [type="checkbox"],
-        [type="radio"] {
-            -webkit-box-sizing: border-box;
-            box-sizing: border-box;
-            padding: 0;
-        }
-
-        [type="number"]::-webkit-inner-spin-button,
-        [type="number"]::-webkit-outer-spin-button {
-            height: auto;
-        }
-
-        [type="search"] {
-            -webkit-appearance: textfield;
-            outline-offset: -2px;
-        }
-
-        [type="search"]::-webkit-search-cancel-button,
-        [type="search"]::-webkit-search-decoration {
-            -webkit-appearance: none;
-        }
-
-        ::-webkit-file-upload-button {
-            -webkit-appearance: button;
-            font: inherit;
-        }
-
-        menu {
-            display: block;
-        }
-
-        canvas {
-            display: inline-block;
-        }
-
-        template {
-            display: none;
-        }
-
-        [hidden] {
-            display: none;
-        }
-
-        html {
-            -webkit-box-sizing: border-box;
-            box-sizing: border-box;
-            font-family: sans-serif;
-        }
-
-        *,
-        *::before,
-        *::after {
-            -webkit-box-sizing: inherit;
-            box-sizing: inherit;
-        }
-
-        p {
-            margin: 0;
-        }
-
-        button {
-            background: transparent;
-            padding: 0;
-        }
-
-        button:focus {
-            outline: 1px dotted;
-            outline: 5px auto -webkit-focus-ring-color;
-        }
-
-        *,
-        *::before,
-        *::after {
-            border-width: 0;
-            border-style: solid;
-            border-color: #dae1e7;
-        }
-
-        button,
-        [type="button"],
-        [type="reset"],
-        [type="submit"] {
-            border-radius: 0;
-        }
-
-        button,
-        input {
-            font-family: inherit;
-        }
-
-        input::-webkit-input-placeholder {
-            color: inherit;
-            opacity: .5;
-        }
-
-        input:-ms-input-placeholder {
-            color: inherit;
-            opacity: .5;
-        }
-
-        input::-ms-input-placeholder {
-            color: inherit;
-            opacity: .5;
-        }
-
-        input::placeholder {
-            color: inherit;
-            opacity: .5;
-        }
-
-        button,
-        [role=button] {
-            cursor: pointer;
-        }
-
-        .bg-transparent {
-            background-color: transparent;
-        }
-
-        .bg-white {
-            background-color: #fff;
-        }
-
-        .bg-teal-light {
-            background-color: #64d5ca;
-        }
-
-        .bg-blue-dark {
-            background-color: #2779bd;
-        }
-
-        .bg-indigo-light {
-            background-color: #7886d7;
-        }
-
-        .bg-purple-light {
-            background-color: #a779e9;
-        }
-
-        .bg-no-repeat {
-            background-repeat: no-repeat;
-        }
-
-        .bg-cover {
-            background-size: cover;
-        }
-
-        .border-grey-light {
-            border-color: #dae1e7;
-        }
-
-        .hover\:border-grey:hover {
-            border-color: #b8c2cc;
-        }
-
-        .rounded-lg {
-            border-radius: .5rem;
-        }
-
-        .border-2 {
-            border-width: 2px;
-        }
-
-        .hidden {
-            display: none;
-        }
-
-        .flex {
-            display: -webkit-box;
-            display: -ms-flexbox;
-            display: flex;
-        }
-
-        .items-center {
-            -webkit-box-align: center;
-            -ms-flex-align: center;
-            align-items: center;
-        }
-
-        .justify-center {
-            -webkit-box-pack: center;
-            -ms-flex-pack: center;
-            justify-content: center;
-        }
-
-        .font-sans {
-            font-family: Nunito, sans-serif;
-        }
-
-        .font-light {
-            font-weight: 300;
-        }
-
-        .font-bold {
-            font-weight: 700;
-        }
-
-        .font-black {
-            font-weight: 900;
-        }
-
-        .h-1 {
-            height: .25rem;
-        }
-
-        .leading-normal {
-            line-height: 1.5;
-        }
-
-        .m-8 {
-            margin: 2rem;
-        }
-
-        .my-3 {
-            margin-top: .75rem;
-            margin-bottom: .75rem;
-        }
-
-        .mb-8 {
-            margin-bottom: 2rem;
-        }
-
-        .max-w-sm {
-            max-width: 30rem;
-        }
-
-        .min-h-screen {
-            min-height: 100vh;
-        }
-
-        .py-3 {
-            padding-top: .75rem;
-            padding-bottom: .75rem;
-        }
-
-        .px-6 {
-            padding-left: 1.5rem;
-            padding-right: 1.5rem;
-        }
-
-        .pb-full {
-            padding-bottom: 100%;
-        }
-
-        .absolute {
-            position: absolute;
-        }
-
-        .relative {
-            position: relative;
-        }
-
-        .pin {
-            top: 0;
-            right: 0;
-            bottom: 0;
-            left: 0;
-        }
-
-        .text-black {
-            color: #22292f;
-        }
-
-        .text-grey-darkest {
-            color: #3d4852;
-        }
-
-        .text-grey-darker {
-            color: #606f7b;
-        }
-
-        .text-2xl {
-            font-size: 1.5rem;
-        }
-
-        .text-5xl {
-            font-size: 3rem;
-        }
-
-        .uppercase {
-            text-transform: uppercase;
-        }
-
-        .antialiased {
-            -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
-        }
-
-        .tracking-wide {
-            letter-spacing: .05em;
-        }
-
-        .w-16 {
-            width: 4rem;
-        }
-
-        .w-full {
-            width: 100%;
-        }
-
-        @media (min-width: 768px) {
-            .md\:bg-left {
-                background-position: left;
-            }
-
-            .md\:bg-right {
-                background-position: right;
-            }
-
-            .md\:flex {
-                display: -webkit-box;
-                display: -ms-flexbox;
-                display: flex;
-            }
-
-            .md\:my-6 {
-                margin-top: 1.5rem;
-                margin-bottom: 1.5rem;
-            }
-
-            .md\:min-h-screen {
-                min-height: 100vh;
-            }
-
-            .md\:pb-0 {
-                padding-bottom: 0;
-            }
-
-            .md\:text-3xl {
-                font-size: 1.875rem;
-            }
-
-            .md\:text-15xl {
-                font-size: 9rem;
-            }
-
-            .md\:w-1\/2 {
-                width: 50%;
-            }
-        }
-
-        @media (min-width: 992px) {
-            .lg\:bg-center {
-                background-position: center;
-            }
-        }
-
-        .bg-morning {
-            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 1024 1024'%3E%3Cdefs%3E%3ClinearGradient id='a' x1='50.31%25' x2='50%25' y1='74.74%25' y2='0%25'%3E%3Cstop offset='0%25' stop-color='%23E26B6B'/%3E%3Cstop offset='50.28%25' stop-color='%23F5BCF4'/%3E%3Cstop offset='100%25' stop-color='%238690E1'/%3E%3C/linearGradient%3E%3ClinearGradient id='b' x1='50%25' x2='50%25' y1='0%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%238C9CE7'/%3E%3Cstop offset='100%25' stop-color='%234353A4'/%3E%3C/linearGradient%3E%3ClinearGradient id='c' x1='50%25' x2='50%25' y1='0%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%23D1D9FF'/%3E%3Cstop offset='100%25' stop-color='%238395EB'/%3E%3C/linearGradient%3E%3Ccircle id='e' cx='622' cy='663' r='60'/%3E%3Cfilter id='d' width='260%25' height='260%25' x='-80%25' y='-80%25' filterUnits='objectBoundingBox'%3E%3CfeOffset in='SourceAlpha' result='shadowOffsetOuter1'/%3E%3CfeGaussianBlur in='shadowOffsetOuter1' result='shadowBlurOuter1' stdDeviation='32'/%3E%3CfeColorMatrix in='shadowBlurOuter1' values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0'/%3E%3C/filter%3E%3ClinearGradient id='f' x1='49.87%25' x2='49.87%25' y1='3.62%25' y2='77.75%25'%3E%3Cstop offset='0%25' stop-color='%23B0DDF1'/%3E%3Cstop offset='100%25' stop-color='%23325C82'/%3E%3C/linearGradient%3E%3ClinearGradient id='g' x1='100%25' x2='72.45%25' y1='0%25' y2='85.2%25'%3E%3Cstop offset='0%25' stop-color='%231D3A6D'/%3E%3Cstop offset='100%25' stop-color='%23467994'/%3E%3C/linearGradient%3E%3ClinearGradient id='h' x1='49.48%25' x2='49.87%25' y1='11.66%25' y2='77.75%25'%3E%3Cstop offset='0%25' stop-color='%23B9C9F7'/%3E%3Cstop offset='100%25' stop-color='%23301863'/%3E%3C/linearGradient%3E%3ClinearGradient id='i' x1='91.59%25' x2='70.98%25' y1='5.89%25' y2='88%25'%3E%3Cstop offset='0%25' stop-color='%232D3173'/%3E%3Cstop offset='100%25' stop-color='%237F90E0'/%3E%3C/linearGradient%3E%3ClinearGradient id='j' x1='70.98%25' x2='70.98%25' y1='9.88%25' y2='88%25'%3E%3Cstop offset='0%25' stop-color='%232D3173'/%3E%3Cstop offset='100%25' stop-color='%237F90E0'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Crect width='1024' height='1024' fill='url(%23a)'/%3E%3Cg transform='translate(211 420)'%3E%3Cpath fill='%238C9CE7' d='M65 0a2 2 0 0 1 2 2v23h-4V2c0-1.1.9-2 2-2z'/%3E%3Cpath fill='%235263B8' d='M64 24h2a3 3 0 0 1 3 3v2h-8v-2a3 3 0 0 1 3-3z'/%3E%3Cpath fill='url(%23b)' d='M65 108h40V68a40 40 0 1 0-80 0v40h40z'/%3E%3Cpolygon fill='%232E3D87' points='0 118 30 112 30 218 0 218'/%3E%3Cpolygon fill='%23301862' points='60 118 30 112 30 218 60 218'/%3E%3Cpath fill='url(%23c)' d='M45 107V68a40.02 40.02 0 0 1 30.03-38.75C92.27 33.65 105 49.11 105 67.5V107H45z'/%3E%3Cpolygon fill='%234353A4' points='15 78 65 68 67 70 67 178 15 178'/%3E%3Cpolygon fill='%238C9CE7' points='115 78 65 68 65 70 65 178 115 178'/%3E%3Cpolygon fill='%234353A4' points='75 118 105 112 105 218 75 218'/%3E%3Cpolygon fill='%238C9CE7' points='135 118 105 112 105 218 135 218'/%3E%3C/g%3E%3Cuse fill='black' filter='url(%23d)' xlink:href='%23e'/%3E%3Cuse fill='%23FFFFFF' xlink:href='%23e'/%3E%3Cg transform='translate(146 245)'%3E%3Cpath fill='url(%23f)' d='M169.12 450.57C192.22 464.04 143.85 532.52 24 656h649C328.94 514.3 160.98 445.83 169.12 450.57z'/%3E%3Cpath fill='url(%23g)' d='M178.5 538.5C137.83 567.17 199.67 606.33 364 656H0l178.5-117.5z'/%3E%3C/g%3E%3Cg transform='translate(0 255)'%3E%3Cpath fill='url(%23h)' d='M1024 685H0V400.08C77.3 366.4 155.26 330 297.4 330c250 0 250.76 125.25 500 125 84.03-.08 160.02-18.2 226.6-40.93V685z'/%3E%3C/g%3E%3Cpath fill='%231F2A68' d='M251 506a8 8 0 0 1 8 8v15l-16 1v-16a8 8 0 0 1 8-8z'/%3E%3Cpath fill='%237C8CDA' d='M253 506.25a8 8 0 0 0-6 7.75v15.75l-4 .25v-16a8 8 0 0 1 10-7.75z'/%3E%3Cpath fill='%231F2A68' d='M251 546a8 8 0 0 1 8 8v15l-16 1v-16a8 8 0 0 1 8-8z'/%3E%3Cpath fill='%237C8CDA' d='M253 546.25a8 8 0 0 0-6 7.75v15.75l-4 .25v-16a8 8 0 0 1 10-7.75z'/%3E%3Cpath fill='%235263B8' d='M301 506a8 8 0 0 1 8 8v16l-16-1v-15a8 8 0 0 1 8-8z'/%3E%3Cpath fill='%23293781' d='M305 529.75V514a8 8 0 0 0-6-7.75 8.01 8.01 0 0 1 10 7.75v16l-4-.25z'/%3E%3Cg transform='translate(0 636)'%3E%3Cpath fill='url(%23h)' d='M1024 356H0V185.82c137.51-15.4 203.1-50.49 356.67-60.1C555.24 113.3 606.71.59 856.74.59 929.52.58 981.18 11.2 1024 26.26V356z'/%3E%3Cpath fill='url(%23i)' d='M1024 26.21V326H856.91c99.31-86.5 112.63-140.75 39.97-162.78C710.24 106.64 795.12.58 856.9.58c72.7 0 124.3 10.6 167.09 25.63z'/%3E%3Cpath fill='url(%23i)' d='M1024 199.32V326H857c99.31-86.6 112.63-140.94 39.97-163L1024 199.32z'/%3E%3C/g%3E%3Ccircle cx='566' cy='599' r='110' fill='%23FFFFFF' opacity='.1'/%3E%3Ccircle cx='669' cy='539' r='60' fill='%23FFFFFF' opacity='.1'/%3E%3Cg transform='translate(0 705)'%3E%3Cpath fill='url(%23h)' d='M0 319V68.93C67.12 35.69 129.55 0 263 0c250 0 331.46 162.6 530 175 107.42 6.71 163-26.77 231-58.92V319H0z'/%3E%3Cpath fill='url(%23i)' d='M353.02 319H0V68.93C67.12 35.69 129.55 0 263 0c71.14 0 151.5 12.76 151.5 70.5 0 54.5-45.5 79.72-112.5 109-82.26 35.95-54.57 111.68 51.02 139.5z'/%3E%3Cpath fill='url(%23j)' d='M353.02 319H0v-14.8l302-124.7c-82.26 35.95-54.57 111.68 51.02 139.5z'/%3E%3C/g%3E%3Ccircle cx='414' cy='799' r='70' fill='%23FFFFFF' opacity='.1'/%3E%3Ccircle cx='479' cy='745' r='30' fill='%23FFFFFF' opacity='.1'/%3E%3Cg fill='%23FFFFFF' opacity='.15' transform='translate(49 214)'%3E%3Cpath d='M554.67 131.48a9.46 9.46 0 0 1 13.33 0 9.46 9.46 0 0 0 13.33 0l13.33-13.24a28.39 28.39 0 0 1 40 0l10 9.93a14.2 14.2 0 0 0 20 0 14.2 14.2 0 0 1 20 0l.6.6a31.8 31.8 0 0 1 9.4 22.56H548v-3.84c0-6.01 2.4-11.78 6.67-16.01zM751 8.25c11.07-11 28.93-11 40 0l10 9.94a14.19 14.19 0 0 0 20 0 14.19 14.19 0 0 1 20 0 16.36 16.36 0 0 0 21.3 1.5l8.7-6.47a33.47 33.47 0 0 1 40 0l4.06 3.03A39.6 39.6 0 0 1 931 48H731c0-12.72 8.93-28.75 20-39.75zM14.1 75.14l.9-.9a21.29 21.29 0 0 1 30 0 21.29 21.29 0 0 0 30 0l10-9.93a35.48 35.48 0 0 1 50 0l15 14.9a14.2 14.2 0 0 0 20 0 14.2 14.2 0 0 1 20 0c6.4 6.35 10 15 10 24.02V109H0c0-12.71 5.07-24.9 14.1-33.86z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
-        }
-
-        .bg-day {
-            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 1024 1024'%3E%3Cdefs%3E%3ClinearGradient id='a' x1='50%25' x2='50%25' y1='100%25' y2='0%25'%3E%3Cstop offset='0%25' stop-color='%23F6EDAE'/%3E%3Cstop offset='100%25' stop-color='%2391D4D7'/%3E%3C/linearGradient%3E%3ClinearGradient id='b' x1='49.87%25' x2='49.87%25' y1='3.62%25' y2='77.75%25'%3E%3Cstop offset='0%25' stop-color='%23B0DDF1'/%3E%3Cstop offset='100%25' stop-color='%23325C82'/%3E%3C/linearGradient%3E%3ClinearGradient id='c' x1='100%25' x2='72.45%25' y1='0%25' y2='85.2%25'%3E%3Cstop offset='0%25' stop-color='%231D3A6D'/%3E%3Cstop offset='100%25' stop-color='%23467994'/%3E%3C/linearGradient%3E%3ClinearGradient id='d' x1='54.81%25' x2='50%25' y1='-18.48%25' y2='59.98%25'%3E%3Cstop offset='0%25' stop-color='%23FFFFFF'/%3E%3Cstop offset='28.15%25' stop-color='%23F8E6B3'/%3E%3Cstop offset='100%25' stop-color='%23D5812F'/%3E%3C/linearGradient%3E%3ClinearGradient id='e' x1='52.84%25' x2='49.87%25' y1='2.8%25' y2='77.75%25'%3E%3Cstop offset='0%25' stop-color='%23FFFFFF'/%3E%3Cstop offset='22.15%25' stop-color='%23F8E6B3'/%3E%3Cstop offset='100%25' stop-color='%23F9D989'/%3E%3C/linearGradient%3E%3ClinearGradient id='f' x1='91.59%25' x2='66.97%25' y1='5.89%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%23CE4014'/%3E%3Cstop offset='100%25' stop-color='%23FFD56E'/%3E%3C/linearGradient%3E%3ClinearGradient id='g' x1='40.28%25' x2='66.37%25' y1='30.88%25' y2='108.51%25'%3E%3Cstop offset='0%25' stop-color='%23A2491E'/%3E%3Cstop offset='100%25' stop-color='%23F4B35A'/%3E%3C/linearGradient%3E%3Ccircle id='i' cx='825' cy='235' r='70'/%3E%3Cfilter id='h' width='237.1%25' height='237.1%25' x='-68.6%25' y='-68.6%25' filterUnits='objectBoundingBox'%3E%3CfeOffset in='SourceAlpha' result='shadowOffsetOuter1'/%3E%3CfeGaussianBlur in='shadowOffsetOuter1' result='shadowBlurOuter1' stdDeviation='32'/%3E%3CfeColorMatrix in='shadowBlurOuter1' values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0'/%3E%3C/filter%3E%3ClinearGradient id='j' x1='50%25' x2='50%25' y1='0%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%23B29959'/%3E%3Cstop offset='100%25' stop-color='%23CEAD5B'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Crect width='1024' height='1024' fill='url(%23a)'/%3E%3Cpath fill='%23FFFFFF' d='M1024 378.13v39.37H790a71.59 71.59 0 0 1 21.14-50.8l1.36-1.34a31.93 31.93 0 0 1 45 0 31.93 31.93 0 0 0 45 0l15-14.9a53.21 53.21 0 0 1 75 0l22.5 22.35a21.2 21.2 0 0 0 9 5.32z' opacity='.15'/%3E%3Cg transform='translate(26 245)'%3E%3Cpath fill='url(%23b)' d='M289.12 450.57C312.22 464.04 263.85 532.52 144 656h649C448.94 514.3 280.98 445.83 289.12 450.57z'/%3E%3Cpath fill='url(%23c)' d='M262.5 402c-48 50 147.33 58.02 36 136.5-40.67 28.67 21.17 67.83 185.5 117.5H0l262.5-254z'/%3E%3Cpath fill='url(%23c)' d='M298.5 538.5C257.83 567.17 319.67 606.33 484 656H120l178.5-117.5z'/%3E%3C/g%3E%3Cpath fill='%23134F4E' d='M783 593.73a29.95 29.95 0 0 1-12-24c0-9.8 4.72-18.52 12-24-5.02 6.69-8 15-8 24 0 9.01 2.98 17.32 8 24z'/%3E%3Cg fill='%23134F4E' transform='matrix(-1 0 0 1 876 532)'%3E%3Cpath d='M24 66.73a29.95 29.95 0 0 1-12-24c0-9.8 4.72-18.52 12-24-5.02 6.69-8 15-8 24 0 9.01 2.98 17.32 8 24z'/%3E%3Cpath d='M36 22.4l-3.96-3.98a5 5 0 0 0-6.5-.5 3 3 0 0 1 3.7-3.55l8.7 2.33a8 8 0 0 1 5.66 9.8l-1-1.73a2 2 0 0 0-1.21-.93L36 22.4zm-5.38-2.56L37 26.2a8 8 0 0 1 0 11.32v-2a2 2 0 0 0-.6-1.42L26.39 24.08a3 3 0 0 1 4.24-4.24zM14.21 9.8l-3.94-3.94a2 2 0 0 0-1.42-.59h-2a8 8 0 0 1 11.32 0l6.36 6.37a3 3 0 0 1-1.22 4.98 5 5 0 0 0-3.68-5.37l-5.42-1.45zm4.9 3.39a3 3 0 1 1-1.55 5.8L3.87 15.31a2 2 0 0 0-1.52.2l-1.73 1a8 8 0 0 1 9.8-5.65l8.7 2.33z'/%3E%3C/g%3E%3Cg transform='translate(0 245)'%3E%3Cpath fill='url(%23d)' d='M1024 423.16V645H58.09c-32.12-75.17-32.12-123.84 0-146 48.17-33.24 127.17-64.25 293.33-64 166.17.25 246.67-105 413.33-105 117.33 0 183.93 55.8 259.25 93.16z'/%3E%3Cpath fill='url(%23e)' d='M1024 778H0V398.62C75.53 363.05 136.43 320 283 320c111.86 0 358.86 69.82 741 209.47V778z'/%3E%3Cpath fill='url(%23f)' d='M0 778V398.62C75.53 363.05 136.43 320 283 320c71.14 0 85.96 26.04 32.5 82-79.5 83.22 279.7 2.01 336 131.5 26 59.8-69.83 141.3-287.48 244.5H0z'/%3E%3Cpath fill='url(%23g)' d='M364.02 778H0V638.4L315.5 402c-79.5 83.22 279.7 2.01 336 131.5 26 59.8-69.83 141.3-287.48 244.5z'/%3E%3C/g%3E%3Cpath fill='%23134F4E' d='M795 549.4l-3.96-3.98a5 5 0 0 0-6.5-.5 3 3 0 0 1 3.7-3.55l8.7 2.33a8 8 0 0 1 5.66 9.8l-1-1.73a2 2 0 0 0-1.21-.93L795 549.4zm-5.38-2.56l6.37 6.36a8 8 0 0 1 0 11.32v-2a2 2 0 0 0-.6-1.42l-10.01-10.02a3 3 0 0 1 4.24-4.24zm-16.41-10.03l-3.94-3.94a2 2 0 0 0-1.42-.59h-2a8 8 0 0 1 11.32 0l6.36 6.37a3 3 0 0 1-1.22 4.98 5 5 0 0 0-3.68-5.37l-5.42-1.45zm4.9 3.39a3 3 0 1 1-1.55 5.8l-13.69-3.68a2 2 0 0 0-1.52.2l-1.73 1a8 8 0 0 1 9.8-5.65l8.7 2.33z'/%3E%3Cpath fill='%23FFFFFF' d='M395.67 116.48a9.46 9.46 0 0 1 13.33 0 9.46 9.46 0 0 0 13.33 0l13.33-13.24a28.39 28.39 0 0 1 40 0l10 9.93a14.2 14.2 0 0 0 20 0 14.2 14.2 0 0 1 20 0l.6.6a31.8 31.8 0 0 1 9.4 22.56H389v-3.84c0-6.01 2.4-11.78 6.67-16.01zM98.1 249.1l5.9-5.86c11.07-11 28.93-11 40 0l10 9.94a14.19 14.19 0 0 0 20 0 14.19 14.19 0 0 1 20 0 16.36 16.36 0 0 0 21.3 1.5l8.7-6.47a33.47 33.47 0 0 1 40 0l4.06 3.03A39.6 39.6 0 0 1 284 283H84a47.77 47.77 0 0 1 14.1-33.89z' opacity='.15'/%3E%3Cuse fill='black' filter='url(%23h)' xlink:href='%23i'/%3E%3Cuse fill='%23FFFFFF' xlink:href='%23i'/%3E%3Cpath fill='%23FFFFFF' d='M702.69 960.64a4.32 4.32 0 0 1-1.04 6.87c-2.26 1.2-3.69 2.1-4.27 2.67-.51.52-1.17 1.4-1.97 2.62a3.53 3.53 0 0 1-5.45.56 3.53 3.53 0 0 1 .56-5.44c1.23-.8 2.1-1.46 2.62-1.98.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.88-1.03z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M700.32 962a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25a3.53 3.53 0 0 1-3.45 4.25 3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9a4.32 4.32 0 0 1 4.13-5.6z' transform='rotate(45 700.323 971)'/%3E%3Cg transform='rotate(-15 3943.802 -2244.376)'%3E%3Cpath fill='%23FFFFFF' d='M16.65 3.9a4.32 4.32 0 0 1-1.03 6.87c-2.27 1.2-3.7 2.1-4.27 2.67-.52.52-1.18 1.4-1.98 2.62a3.53 3.53 0 0 1-5.44.56 3.53 3.53 0 0 1 .56-5.44c1.23-.8 2.1-1.46 2.62-1.98.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.87-1.03z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M13.32 5a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 13.32 23a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 13.32 5z' transform='rotate(45 13.323 14)'/%3E%3C/g%3E%3Cg transform='rotate(-15 4117.1 -2152.014)'%3E%3Cpath fill='%23FFFFFF' d='M16.65 3.9a4.32 4.32 0 0 1-1.03 6.87c-2.27 1.2-3.7 2.1-4.27 2.67-.52.52-1.18 1.4-1.98 2.62a3.53 3.53 0 0 1-5.44.56 3.53 3.53 0 0 1 .56-5.44c1.23-.8 2.1-1.46 2.62-1.98.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.87-1.03z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M13.32 5a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 13.32 23a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 13.32 5z' transform='rotate(45 13.323 14)'/%3E%3C/g%3E%3Cg transform='rotate(-15 4127.186 -2023.184)'%3E%3Cpath fill='%23FFFFFF' d='M16.65 3.9a4.32 4.32 0 0 1-1.03 6.87c-2.27 1.2-3.7 2.1-4.27 2.67-.52.52-1.18 1.4-1.98 2.62a3.53 3.53 0 0 1-5.44.56 3.53 3.53 0 0 1 .56-5.44c1.23-.8 2.1-1.46 2.62-1.98.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.87-1.03z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M13.32 5a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 13.32 23a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 13.32 5z' transform='rotate(45 13.323 14)'/%3E%3C/g%3E%3Cg transform='rotate(-30 2055.753 -866.842)'%3E%3Cpath fill='%23FFFFFF' d='M16.55 3.4a4.32 4.32 0 0 1-1.03 6.88c-2.27 1.2-3.7 2.1-4.27 2.67-.52.52-1.18 1.39-1.98 2.62a3.53 3.53 0 0 1-5.44.56 3.53 3.53 0 0 1 .56-5.44c1.23-.8 2.1-1.46 2.62-1.98.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.87-1.04z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M12.32 6a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 12.32 24a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 12.32 6z' transform='rotate(45 12.323 15)'/%3E%3C/g%3E%3Cg transform='rotate(-30 2046.995 -931.189)'%3E%3Cpath fill='%23FFFFFF' d='M16.55 3.4a4.32 4.32 0 0 1-1.03 6.88c-2.27 1.2-3.7 2.1-4.27 2.67-.52.52-1.18 1.39-1.98 2.62a3.53 3.53 0 0 1-5.44.56 3.53 3.53 0 0 1 .56-5.44c1.23-.8 2.1-1.46 2.62-1.98.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.87-1.04z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M12.32 6a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 12.32 24a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 12.32 6z' transform='rotate(45 12.323 15)'/%3E%3C/g%3E%3Cg transform='rotate(-45 1406.147 -409.132)'%3E%3Cpath fill='%23FFFFFF' d='M16.93 3.22a4.32 4.32 0 0 1-1.03 6.88c-2.27 1.2-3.7 2.09-4.27 2.67-.52.52-1.18 1.39-1.98 2.61a3.53 3.53 0 0 1-5.45.57 3.53 3.53 0 0 1 .57-5.45c1.22-.8 2.1-1.46 2.61-1.97.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.88-1.04z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M10.32 6a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 10.32 24a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 10.32 6z' transform='rotate(45 10.323 15)'/%3E%3C/g%3E%3Cg transform='rotate(-24 2389.63 -1296.285)'%3E%3Cpath fill='%23FFFFFF' d='M16.93 3.22a4.32 4.32 0 0 1-1.03 6.88c-2.27 1.2-3.7 2.09-4.27 2.67-.52.52-1.18 1.39-1.98 2.61a3.53 3.53 0 0 1-5.45.57 3.53 3.53 0 0 1 .57-5.45c1.22-.8 2.1-1.46 2.61-1.97.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.88-1.04z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M10.32 6a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 10.32 24a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 10.32 6z' transform='rotate(45 10.323 15)'/%3E%3C/g%3E%3Cg transform='rotate(-50 1258.425 -353.155)'%3E%3Cpath fill='%23FFFFFF' d='M16.93 3.22a4.32 4.32 0 0 1-1.03 6.88c-2.27 1.2-3.7 2.09-4.27 2.67-.52.52-1.18 1.39-1.98 2.61a3.53 3.53 0 0 1-5.45.57 3.53 3.53 0 0 1 .57-5.45c1.22-.8 2.1-1.46 2.61-1.97.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.88-1.04z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M10.32 6a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 10.32 24a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 10.32 6z' transform='rotate(45 10.323 15)'/%3E%3C/g%3E%3Cg transform='rotate(-35 1652.744 -777.703)'%3E%3Cpath fill='%23FFFFFF' d='M16.08 3.06a4.1 4.1 0 0 1-.98 6.53c-2.15 1.14-3.5 1.99-4.05 2.54-.5.5-1.12 1.32-1.88 2.49a3.35 3.35 0 0 1-5.18.53 3.35 3.35 0 0 1 .54-5.17c1.16-.76 2-1.39 2.48-1.88.55-.55 1.4-1.9 2.54-4.06a4.1 4.1 0 0 1 6.53-.98z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M9.8 5.7a4.1 4.1 0 0 1 3.93 5.31c-.71 2.33-1.07 3.89-1.07 4.67 0 .69.14 1.72.43 3.08A3.35 3.35 0 0 1 9.8 22.8a3.35 3.35 0 0 1-3.28-4.04c.28-1.36.43-2.39.43-3.09 0-.77-.36-2.33-1.08-4.66A4.1 4.1 0 0 1 9.81 5.7z' transform='rotate(45 9.807 14.25)'/%3E%3C/g%3E%3Cg transform='rotate(-35 1605.77 -758.112)'%3E%3Cpath fill='%23FFFFFF' d='M15.24 2.9a3.89 3.89 0 0 1-.93 6.19c-2.04 1.08-3.33 1.88-3.85 2.4a15.6 15.6 0 0 0-1.78 2.36 3.17 3.17 0 0 1-4.9.5 3.17 3.17 0 0 1 .51-4.9 15.6 15.6 0 0 0 2.36-1.78c.52-.52 1.32-1.8 2.4-3.84a3.89 3.89 0 0 1 6.19-.93z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M9.3 5.4a3.89 3.89 0 0 1 3.7 5.03c-.67 2.21-1 3.68-1 4.42 0 .66.13 1.63.4 2.92a3.17 3.17 0 0 1-3.1 3.83 3.17 3.17 0 0 1-3.12-3.83c.28-1.29.41-2.26.41-2.92 0-.74-.34-2.2-1.02-4.42A3.89 3.89 0 0 1 9.3 5.4z' transform='rotate(45 9.29 13.5)'/%3E%3C/g%3E%3Cg transform='rotate(-35 1591.812 -807.843)'%3E%3Cpath fill='%23FFFFFF' d='M15.24 2.9a3.89 3.89 0 0 1-.93 6.19c-2.04 1.08-3.33 1.88-3.85 2.4a15.6 15.6 0 0 0-1.78 2.36 3.17 3.17 0 0 1-4.9.5 3.17 3.17 0 0 1 .51-4.9 15.6 15.6 0 0 0 2.36-1.78c.52-.52 1.32-1.8 2.4-3.84a3.89 3.89 0 0 1 6.19-.93z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M9.3 5.4a3.89 3.89 0 0 1 3.7 5.03c-.67 2.21-1 3.68-1 4.42 0 .66.13 1.63.4 2.92a3.17 3.17 0 0 1-3.1 3.83 3.17 3.17 0 0 1-3.12-3.83c.28-1.29.41-2.26.41-2.92 0-.74-.34-2.2-1.02-4.42A3.89 3.89 0 0 1 9.3 5.4z' transform='rotate(45 9.29 13.5)'/%3E%3C/g%3E%3Cg transform='rotate(-44 1287.793 -536.004)'%3E%3Cpath fill='%23FFFFFF' d='M15.24 2.9a3.89 3.89 0 0 1-.93 6.19c-2.04 1.08-3.33 1.88-3.85 2.4a15.6 15.6 0 0 0-1.78 2.36 3.17 3.17 0 0 1-4.9.5 3.17 3.17 0 0 1 .51-4.9 15.6 15.6 0 0 0 2.36-1.78c.52-.52 1.32-1.8 2.4-3.84a3.89 3.89 0 0 1 6.19-.93z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M9.3 5.4a3.89 3.89 0 0 1 3.7 5.03c-.67 2.21-1 3.68-1 4.42 0 .66.13 1.63.4 2.92a3.17 3.17 0 0 1-3.1 3.83 3.17 3.17 0 0 1-3.12-3.83c.28-1.29.41-2.26.41-2.92 0-.74-.34-2.2-1.02-4.42A3.89 3.89 0 0 1 9.3 5.4z' transform='rotate(45 9.29 13.5)'/%3E%3C/g%3E%3Cg transform='rotate(-28 1831.874 -1151.097)'%3E%3Cpath fill='%23FFFFFF' d='M15.24 2.9a3.89 3.89 0 0 1-.93 6.19c-2.04 1.08-3.33 1.88-3.85 2.4a15.6 15.6 0 0 0-1.78 2.36 3.17 3.17 0 0 1-4.9.5 3.17 3.17 0 0 1 .51-4.9 15.6 15.6 0 0 0 2.36-1.78c.52-.52 1.32-1.8 2.4-3.84a3.89 3.89 0 0 1 6.19-.93z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M9.3 5.4a3.89 3.89 0 0 1 3.7 5.03c-.67 2.21-1 3.68-1 4.42 0 .66.13 1.63.4 2.92a3.17 3.17 0 0 1-3.1 3.83 3.17 3.17 0 0 1-3.12-3.83c.28-1.29.41-2.26.41-2.92 0-.74-.34-2.2-1.02-4.42A3.89 3.89 0 0 1 9.3 5.4z' transform='rotate(45 9.29 13.5)'/%3E%3C/g%3E%3Cg transform='rotate(-41 1316.639 -621.138)'%3E%3Cpath fill='%23FFFFFF' d='M13.54 2.58a3.46 3.46 0 0 1-.82 5.5A17.18 17.18 0 0 0 9.3 10.2c-.41.42-.94 1.12-1.58 2.1a2.82 2.82 0 0 1-4.36.45 2.82 2.82 0 0 1 .45-4.36c.99-.64 1.68-1.17 2.1-1.58.46-.46 1.17-1.6 2.13-3.42a3.46 3.46 0 0 1 5.5-.82z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M8.26 4.8a3.46 3.46 0 0 1 3.3 4.47c-.6 1.97-.9 3.27-.9 3.93 0 .59.12 1.45.36 2.6a2.82 2.82 0 0 1-2.76 3.4 2.82 2.82 0 0 1-2.76-3.4c.24-1.15.36-2.01.36-2.6 0-.66-.3-1.96-.9-3.93a3.46 3.46 0 0 1 3.3-4.47z' transform='rotate(45 8.258 12)'/%3E%3C/g%3E%3Cg transform='rotate(-41 1286.706 -646.924)'%3E%3Cpath fill='%23FFFFFF' d='M11.85 2.26a3.03 3.03 0 0 1-.72 4.8 15.04 15.04 0 0 0-3 1.88c-.35.36-.82.97-1.38 1.83a2.47 2.47 0 0 1-3.8.4 2.47 2.47 0 0 1 .39-3.82C4.2 6.8 4.8 6.33 5.17 5.97c.4-.4 1.03-1.4 1.87-3a3.03 3.03 0 0 1 4.81-.71z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M7.23 4.2a3.03 3.03 0 0 1 2.89 3.91c-.53 1.72-.8 2.87-.8 3.44 0 .51.11 1.27.32 2.27a2.47 2.47 0 0 1-2.41 2.98 2.47 2.47 0 0 1-2.42-2.98c.21-1 .32-1.76.32-2.27 0-.57-.27-1.72-.8-3.44a3.03 3.03 0 0 1 2.9-3.91z' transform='rotate(45 7.226 10.5)'/%3E%3C/g%3E%3Cg transform='rotate(-24 2011.85 -1427.831)'%3E%3Cpath fill='%23FFFFFF' d='M13.54 2.58a3.46 3.46 0 0 1-.82 5.5A17.18 17.18 0 0 0 9.3 10.2c-.41.42-.94 1.12-1.58 2.1a2.82 2.82 0 0 1-4.36.45 2.82 2.82 0 0 1 .45-4.36c.99-.64 1.68-1.17 2.1-1.58.46-.46 1.17-1.6 2.13-3.42a3.46 3.46 0 0 1 5.5-.82z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M8.26 4.8a3.46 3.46 0 0 1 3.3 4.47c-.6 1.97-.9 3.27-.9 3.93 0 .59.12 1.45.36 2.6a2.82 2.82 0 0 1-2.76 3.4 2.82 2.82 0 0 1-2.76-3.4c.24-1.15.36-2.01.36-2.6 0-.66-.3-1.96-.9-3.93a3.46 3.46 0 0 1 3.3-4.47z' transform='rotate(45 8.258 12)'/%3E%3C/g%3E%3Ccircle cx='756' cy='209' r='110' fill='%23FFFFFF' opacity='.2'/%3E%3Ccircle cx='859' cy='139' r='40' fill='%23FFFFFF' opacity='.2'/%3E%3Ccircle cx='551' cy='383' r='70' fill='%23FFFFFF' opacity='.2'/%3E%3Ccircle cx='666' cy='359' r='30' fill='%23FFFFFF' opacity='.2'/%3E%3Crect width='60' height='6' x='722' y='547' fill='%23FFFFFF' opacity='.4' rx='3'/%3E%3Crect width='60' height='6' x='842' y='565' fill='%23FFFFFF' opacity='.4' rx='3'/%3E%3Crect width='40' height='6' x='762' y='559' fill='%23FFFFFF' opacity='.4' rx='3'/%3E%3Crect width='40' height='6' x='872' y='553' fill='%23FFFFFF' opacity='.4' rx='3'/%3E%3Crect width='40' height='6' x='811' y='547' fill='%23FFFFFF' opacity='.4' rx='3'/%3E%3C/g%3E%3C/svg%3E");
-        }
-
-        .bg-evening {
-            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 1024 1024'%3E%3Cdefs%3E%3ClinearGradient id='a' x1='50.31%25' x2='50%25' y1='74.74%25' y2='0%25'%3E%3Cstop offset='0%25' stop-color='%23FFE98A'/%3E%3Cstop offset='67.7%25' stop-color='%23B63E59'/%3E%3Cstop offset='100%25' stop-color='%2368126F'/%3E%3C/linearGradient%3E%3Ccircle id='c' cx='603' cy='682' r='93'/%3E%3Cfilter id='b' width='203.2%25' height='203.2%25' x='-51.6%25' y='-51.6%25' filterUnits='objectBoundingBox'%3E%3CfeOffset in='SourceAlpha' result='shadowOffsetOuter1'/%3E%3CfeGaussianBlur in='shadowOffsetOuter1' result='shadowBlurOuter1' stdDeviation='32'/%3E%3CfeColorMatrix in='shadowBlurOuter1' values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0'/%3E%3C/filter%3E%3ClinearGradient id='d' x1='49.48%25' x2='49.87%25' y1='11.66%25' y2='77.75%25'%3E%3Cstop offset='0%25' stop-color='%23F7EAB9'/%3E%3Cstop offset='100%25' stop-color='%23E5765E'/%3E%3C/linearGradient%3E%3ClinearGradient id='e' x1='91.59%25' x2='66.97%25' y1='5.89%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%23A22A50'/%3E%3Cstop offset='100%25' stop-color='%23EE7566'/%3E%3C/linearGradient%3E%3ClinearGradient id='f' x1='49.48%25' x2='49.61%25' y1='11.66%25' y2='98.34%25'%3E%3Cstop offset='0%25' stop-color='%23F7EAB9'/%3E%3Cstop offset='100%25' stop-color='%23E5765E'/%3E%3C/linearGradient%3E%3ClinearGradient id='g' x1='78.5%25' x2='36.4%25' y1='106.76%25' y2='26.41%25'%3E%3Cstop offset='0%25' stop-color='%23A22A50'/%3E%3Cstop offset='100%25' stop-color='%23EE7566'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Crect width='1024' height='1024' fill='url(%23a)'/%3E%3Cuse fill='black' filter='url(%23b)' xlink:href='%23c'/%3E%3Cuse fill='%23FFF6CB' xlink:href='%23c'/%3E%3Cg fill='%23FFFFFF' opacity='.3' transform='translate(14 23)'%3E%3Ccircle cx='203' cy='255' r='3' fill-opacity='.4'/%3E%3Ccircle cx='82' cy='234' r='2'/%3E%3Ccircle cx='22' cy='264' r='2' opacity='.4'/%3E%3Ccircle cx='113' cy='65' r='3'/%3E%3Ccircle cx='202' cy='2' r='2'/%3E%3Ccircle cx='2' cy='114' r='2'/%3E%3Ccircle cx='152' cy='144' r='2'/%3E%3Ccircle cx='362' cy='224' r='2'/%3E%3Ccircle cx='453' cy='65' r='3' opacity='.4'/%3E%3Ccircle cx='513' cy='255' r='3'/%3E%3Ccircle cx='593' cy='115' r='3'/%3E%3Ccircle cx='803' cy='5' r='3' opacity='.4'/%3E%3Ccircle cx='502' cy='134' r='2'/%3E%3Ccircle cx='832' cy='204' r='2'/%3E%3Ccircle cx='752' cy='114' r='2'/%3E%3Ccircle cx='933' cy='255' r='3' opacity='.4'/%3E%3Ccircle cx='703' cy='225' r='3'/%3E%3Ccircle cx='903' cy='55' r='3'/%3E%3Ccircle cx='982' cy='144' r='2'/%3E%3Ccircle cx='632' cy='14' r='2'/%3E%3C/g%3E%3Cg transform='translate(0 550)'%3E%3Cpath fill='%238E2C15' d='M259 5.47c0 5.33 3.33 9.5 10 12.5s9.67 9.16 9 18.5h1c.67-6.31 1-11.8 1-16.47 8.67 0 13.33-1.33 14-4 .67 4.98 1.67 8.3 3 9.97 1.33 1.66 2 5.16 2 10.5h1c0-5.65.33-9.64 1-11.97 1-3.5 4-10.03-1-14.53S295 7 290 3c-5-4-10-3-13 2s-5 7-9 7-5-3.53-5-5.53c0-2 2-5-1.5-5s-7.5 0-7.5 2c0 1.33 1.67 2 5 2z'/%3E%3Cpath fill='url(%23d)' d='M1024 390H0V105.08C77.3 71.4 155.26 35 297.4 35c250 0 250.76 125.25 500 125 84.03-.08 160.02-18.2 226.6-40.93V390z'/%3E%3Cpath fill='url(%23d)' d='M1024 442H0V271.82c137.51-15.4 203.1-50.49 356.67-60.1C555.24 199.3 606.71 86.59 856.74 86.59c72.78 0 124.44 10.62 167.26 25.68V442z'/%3E%3Cpath fill='url(%23e)' d='M1024 112.21V412H856.91c99.31-86.5 112.63-140.75 39.97-162.78C710.24 192.64 795.12 86.58 856.9 86.58c72.7 0 124.3 10.6 167.09 25.63z'/%3E%3Cpath fill='url(%23e)' d='M1024 285.32V412H857c99.31-86.6 112.63-140.94 39.97-163L1024 285.32z'/%3E%3Cpath fill='url(%23f)' d='M0 474V223.93C67.12 190.69 129.55 155 263 155c250 0 331.46 162.6 530 175 107.42 6.71 163-26.77 231-58.92V474H0z'/%3E%3Cpath fill='url(%23e)' d='M353.02 474H0V223.93C67.12 190.69 129.55 155 263 155c71.14 0 151.5 12.76 151.5 70.5 0 54.5-45.5 79.72-112.5 109-82.26 35.95-54.57 111.68 51.02 139.5z'/%3E%3Cpath fill='url(%23g)' d='M353.02 474H0v-14.8l302-124.7c-82.26 35.95-54.57 111.68 51.02 139.5z'/%3E%3C/g%3E%3Cg fill='%23FFFFFF' opacity='.2' transform='translate(288 523)'%3E%3Ccircle cx='250' cy='110' r='110'/%3E%3Ccircle cx='420' cy='78' r='60'/%3E%3Ccircle cx='70' cy='220' r='70'/%3E%3C/g%3E%3Cg fill='%23FFFFFF' fill-rule='nonzero' opacity='.08' transform='translate(135 316)'%3E%3Cpath d='M10 80.22a14.2 14.2 0 0 1 20 0 14.2 14.2 0 0 0 20 0l20-19.86a42.58 42.58 0 0 1 60 0l15 14.9a21.3 21.3 0 0 0 30 0 21.3 21.3 0 0 1 30 0l.9.9A47.69 47.69 0 0 1 220 110H0v-5.76c0-9.02 3.6-17.67 10-24.02zm559.1-66.11l5.9-5.86c11.07-11 28.93-11 40 0l10 9.94a14.19 14.19 0 0 0 20 0 14.19 14.19 0 0 1 20 0 16.36 16.36 0 0 0 21.3 1.5l8.7-6.47a33.47 33.47 0 0 1 40 0l4.06 3.03A39.6 39.6 0 0 1 755 48H555a47.77 47.77 0 0 1 14.1-33.89z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
-        }
-
-        .bg-night {
-            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 1024 1024'%3E%3Cdefs%3E%3ClinearGradient id='a' x1='50%25' x2='50%25' y1='100%25' y2='0%25'%3E%3Cstop offset='0%25' stop-color='%2376C3C3'/%3E%3Cstop offset='100%25' stop-color='%23183468'/%3E%3C/linearGradient%3E%3ClinearGradient id='b' x1='100%25' x2='0%25' y1='50%25' y2='50%25'%3E%3Cstop offset='0%25' stop-color='%23486587'/%3E%3Cstop offset='33.23%25' stop-color='%23183352'/%3E%3Cstop offset='66.67%25' stop-color='%23264A6E'/%3E%3Cstop offset='100%25' stop-color='%23183352'/%3E%3C/linearGradient%3E%3ClinearGradient id='c' x1='49.87%25' x2='48.5%25' y1='3.62%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%23E0F2FA'/%3E%3Cstop offset='8.98%25' stop-color='%2389BED6'/%3E%3Cstop offset='32.98%25' stop-color='%231E3C6E'/%3E%3Cstop offset='100%25' stop-color='%231B376B'/%3E%3C/linearGradient%3E%3ClinearGradient id='d' x1='49.87%25' x2='49.87%25' y1='3.62%25' y2='77.75%25'%3E%3Cstop offset='0%25' stop-color='%23B0DDF1'/%3E%3Cstop offset='100%25' stop-color='%23325C82'/%3E%3C/linearGradient%3E%3ClinearGradient id='e' x1='91.59%25' x2='66.97%25' y1='5.89%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%231D3A6D'/%3E%3Cstop offset='100%25' stop-color='%23467994'/%3E%3C/linearGradient%3E%3ClinearGradient id='f' x1='97.27%25' x2='52.53%25' y1='6.88%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%231D3A6D'/%3E%3Cstop offset='100%25' stop-color='%23467994'/%3E%3C/linearGradient%3E%3ClinearGradient id='g' x1='82.73%25' x2='41.46%25' y1='41.06%25' y2='167.23%25'%3E%3Cstop offset='0%25' stop-color='%231D3A6D'/%3E%3Cstop offset='100%25' stop-color='%23467994'/%3E%3C/linearGradient%3E%3ClinearGradient id='h' x1='49.87%25' x2='49.87%25' y1='3.62%25' y2='100.77%25'%3E%3Cstop offset='0%25' stop-color='%23B0DDF1'/%3E%3Cstop offset='100%25' stop-color='%23325C82'/%3E%3C/linearGradient%3E%3ClinearGradient id='i' x1='100%25' x2='72.45%25' y1='0%25' y2='85.2%25'%3E%3Cstop offset='0%25' stop-color='%231D3A6D'/%3E%3Cstop offset='100%25' stop-color='%23467994'/%3E%3C/linearGradient%3E%3ClinearGradient id='j' x1='100%25' x2='62.1%25' y1='0%25' y2='68.86%25'%3E%3Cstop offset='0%25' stop-color='%23163055'/%3E%3Cstop offset='100%25' stop-color='%232F587F'/%3E%3C/linearGradient%3E%3Ccircle id='l' cx='180' cy='102' r='40'/%3E%3Cfilter id='k' width='340%25' height='340%25' x='-120%25' y='-120%25' filterUnits='objectBoundingBox'%3E%3CfeOffset in='SourceAlpha' result='shadowOffsetOuter1'/%3E%3CfeGaussianBlur in='shadowOffsetOuter1' result='shadowBlurOuter1' stdDeviation='32'/%3E%3CfeColorMatrix in='shadowBlurOuter1' values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.696473053 0'/%3E%3C/filter%3E%3ClinearGradient id='m' x1='0%25' y1='50%25' y2='50%25'%3E%3Cstop offset='0%25' stop-color='%23FFFFFF' stop-opacity='0'/%3E%3Cstop offset='100%25' stop-color='%23FFFFFF'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Crect width='1024' height='1024' fill='url(%23a)'/%3E%3Cg transform='translate(761 481)'%3E%3Cpolygon fill='%238DBCD2' points='96 27 100 26 100 37 96 37'/%3E%3Cpolygon fill='%238DBCD2' points='76 23 80 22 80 37 76 37'/%3E%3Cpolygon fill='%23183352' points='40 22 44 23 44 37 40 37'/%3E%3Cpolygon fill='%23183352' points='20 26 24 27 24 41 20 41'/%3E%3Crect width='2' height='20' x='59' fill='%23183352' opacity='.5'/%3E%3Cpath fill='url(%23b)' d='M61 0c3 0 3 2 6 2s3-2 6-2 3 2 6 2v8c-3 0-3-2-6-2s-3 2-6 2-3-2-6-2V0z'/%3E%3Cpath fill='%238DBCD2' d='M50 20l10-2v110H0L10 28l10-2v10.92l10-.98V24l10-2v12.96l10-.98V20z'/%3E%3Cpath fill='%23183352' d='M100 26l10 2 10 100H60V18l10 2v13.98l10 .98V22l10 2v11.94l10 .98V26z'/%3E%3C/g%3E%3Cg transform='translate(0 565)'%3E%3Cpath fill='url(%23c)' d='M1024 385H0V106.86c118.4 21.09 185.14 57.03 327.4 48.14 198.54-12.4 250-125 500-125 90.18 0 147.92 16.3 196.6 37.12V385z'/%3E%3Cpath fill='url(%23d)' d='M1024 355H0V79.56C76.46 43.81 137.14 0 285 0c250 0 301.46 112.6 500 125 103.24 6.45 166.7-10.7 239-28.66V355z'/%3E%3Cpath fill='url(%23d)' d='M344.12 130.57C367.22 144.04 318.85 212.52 199 336h649C503.94 194.3 335.98 125.83 344.12 130.57z'/%3E%3Cpath fill='url(%23e)' d='M0 336V79.56C76.46 43.81 137.14 0 285 0c71.14 0 86.22 26.04 32.5 82-48 50 147.33 58.02 36 136.5-40.67 28.67 21.17 67.83 185.5 117.5H0z'/%3E%3Cpath fill='url(%23f)' d='M317.5 82c-48 50 147.33 58.02 36 136.5-40.67 28.67 21.17 67.83 185.5 117.5H55L317.5 82z'/%3E%3Cpath fill='url(%23g)' d='M353.5 218.5C312.83 247.17 374.67 286.33 539 336H175l178.5-117.5z'/%3E%3Cpath fill='url(%23h)' d='M0 459V264.54c100.25 21.2 167.18 50.29 296.67 42.19 198.57-12.43 250.04-125.15 500.07-125.15 109.75 0 171.47 24.16 227.26 51.25V459H0z'/%3E%3Cpath fill='url(%23i)' d='M1024 459H846.16c51.95-58.9 48.86-97.16-9.28-114.78-186.64-56.58-101.76-162.64-39.97-162.64 109.64 0 171.34 24.12 227.09 51.19V459z'/%3E%3Cpath fill='url(%23j)' d='M1024 459H846.19c52.01-59.01 48.94-97.34-9.22-115L1024 397.48V459z'/%3E%3C/g%3E%3Cg transform='translate(94 23)'%3E%3Cuse fill='black' filter='url(%23k)' xlink:href='%23l'/%3E%3Cuse fill='%23D2F1FE' xlink:href='%23l'/%3E%3Ccircle cx='123' cy='255' r='3' fill='%23FFFFFF' fill-opacity='.4'/%3E%3Ccircle cx='2' cy='234' r='2' fill='%23FFFFFF'/%3E%3Ccircle cx='33' cy='65' r='3' fill='%23FFFFFF'/%3E%3Ccircle cx='122' cy='2' r='2' fill='%23FFFFFF'/%3E%3Ccircle cx='72' cy='144' r='2' fill='%23FFFFFF'/%3E%3Ccircle cx='282' cy='224' r='2' fill='%23FFFFFF'/%3E%3Ccircle cx='373' cy='65' r='3' fill='%23FFFFFF' opacity='.4'/%3E%3Ccircle cx='433' cy='255' r='3' fill='%23FFFFFF'/%3E%3Cpath fill='url(%23m)' d='M373.25 325.25a5 5 0 0 0 0-10h-75v10h75z' opacity='.4' transform='rotate(45 338.251 320.251)'/%3E%3Ccircle cx='363' cy='345' r='3' fill='%23FFFFFF'/%3E%3Ccircle cx='513' cy='115' r='3' fill='%23FFFFFF'/%3E%3Ccircle cx='723' cy='5' r='3' fill='%23FFFFFF' opacity='.4'/%3E%3Ccircle cx='422' cy='134' r='2' fill='%23FFFFFF'/%3E%3Ccircle cx='752' cy='204' r='2' fill='%23FFFFFF'/%3E%3Ccircle cx='672' cy='114' r='2' fill='%23FFFFFF'/%3E%3Ccircle cx='853' cy='255' r='3' fill='%23FFFFFF' opacity='.4'/%3E%3Ccircle cx='623' cy='225' r='3' fill='%23FFFFFF'/%3E%3Ccircle cx='823' cy='55' r='3' fill='%23FFFFFF'/%3E%3Ccircle cx='902' cy='144' r='2' fill='%23FFFFFF'/%3E%3Ccircle cx='552' cy='14' r='2' fill='%23FFFFFF'/%3E%3C/g%3E%3Cpath fill='%23486587' d='M796 535a4 4 0 0 1 4 4v20h-8v-20a4 4 0 0 1 4-4z'/%3E%3Cpath fill='%23071423' d='M798 535.54a4 4 0 0 0-2 3.46v20h-4v-20a4 4 0 0 1 6-3.46zm48-.54a4 4 0 0 1 4 4v20h-8v-20a4 4 0 0 1 4-4z'/%3E%3Cpath fill='%238DBCD2' d='M846 559v-20a4 4 0 0 0-2-3.46 4 4 0 0 1 6 3.46v20h-4z'/%3E%3Cg fill='%23FFFFFF' opacity='.07' transform='translate(54 301)'%3E%3Cpath d='M554.67 131.48a9.46 9.46 0 0 1 13.33 0 9.46 9.46 0 0 0 13.33 0l13.33-13.24a28.39 28.39 0 0 1 40 0l10 9.93a14.2 14.2 0 0 0 20 0 14.2 14.2 0 0 1 20 0l.6.6a31.8 31.8 0 0 1 9.4 22.56H548v-3.84c0-6.01 2.4-11.78 6.67-16.01zM751 8.25c11.07-11 28.93-11 40 0l10 9.94a14.19 14.19 0 0 0 20 0 14.19 14.19 0 0 1 20 0 16.36 16.36 0 0 0 21.3 1.5l8.7-6.47a33.47 33.47 0 0 1 40 0l4.06 3.03A39.6 39.6 0 0 1 931 48H731c0-12.72 8.93-28.75 20-39.75zM14.1 75.14l.9-.9a21.29 21.29 0 0 1 30 0 21.29 21.29 0 0 0 30 0l10-9.93a35.48 35.48 0 0 1 50 0l15 14.9a14.2 14.2 0 0 0 20 0 14.2 14.2 0 0 1 20 0c6.4 6.35 10 15 10 24.02V109H0c0-12.71 5.07-24.9 14.1-33.86z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
-        }
-    </style>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex, nofollow"/>
+  <link rel="preconnect" href="https://fonts.bunny.net" crossorigin>
+  <link rel="dns-prefetch" href="https://fonts.bunny.net">
+  <link href="https://fonts.bunny.net/css?family=Nunito&display=swap" rel="stylesheet">
+  <title>{{ message }}</title>
+  <style>
+    :root {
+      --color-bg-primary: #fff;
+      --color-text-primary: #22292f;
+      --color-text-secondary: #606f7b;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --color-bg-primary: #212121;
+        --color-text-primary: #fafafa;
+        --color-text-secondary: #9db6cb;
+      }
+    }
+
+    html, body {
+      height: 100%;
+      line-height: 1.15;
+      text-size-adjust: 100%;
+      box-sizing: border-box;
+      font-family: Nunito, sans-serif;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      margin: 0;
+      padding: 0;
+      background-color: var(--color-bg-primary);
+    }
+
+    *,
+    *::before,
+    *::after {
+      box-sizing: inherit;
+      border-style: none;
+    }
+
+    p {
+      margin: 0;
+    }
+
+    main {
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
+    }
+
+    main .left, main .right {
+      width: 100%;
+    }
+
+    main .left .container {
+      max-width: 30rem;
+      margin: 2rem;
+    }
+
+    main .left .container .code {
+      color: var(--color-text-primary);
+      font-size: 3rem;
+      font-weight: 900;
+    }
+
+    main .left .container .space {
+      width: 4rem;
+      height: .25rem;
+      background-color: #a779e9;
+      margin-top: .75rem;
+      margin-bottom: .75rem;
+    }
+
+    main .left .container .description {
+      color: var(--color-text-secondary);
+      font-size: 1.5rem;
+      margin-bottom: 2rem;
+    }
+
+    main .right {
+      height: 100%;
+    }
+
+    main .right .container {
+      width: 100%;
+      height: 100%;
+      background-size: cover;
+      background-repeat: no-repeat;
+      /* {{ if eq code "404" }} */
+      /* https://github.com/LaravelCollective/errors/blob/8a0cf6fb73ba0041330967d3d6a137bd4509f7bd/src/publish/svg/404.svg */
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 1024 1024'%3E%3Cdefs%3E%3ClinearGradient id='A' x1='50.31%25' x2='50%25' y1='74.74%25' y2='0%25'%3E%3Cstop offset='0%25' stop-color='%23ffe98a'/%3E%3Cstop offset='67.7%25' stop-color='%23b63e59'/%3E%3Cstop offset='100%25' stop-color='%2368126f'/%3E%3C/linearGradient%3E%3Ccircle id='B' cx='603' cy='682' r='93'/%3E%3Cfilter id='C' width='203.2%25' height='203.2%25' x='-51.6%25' y='-51.6%25'%3E%3CfeOffset in='SourceAlpha'/%3E%3CfeGaussianBlur stdDeviation='32'/%3E%3CfeColorMatrix values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0'/%3E%3C/filter%3E%3ClinearGradient id='D' x1='49.48%25' x2='49.87%25' y1='11.66%25' y2='77.75%25'%3E%3Cstop offset='0%25' stop-color='%23f7eab9'/%3E%3Cstop offset='100%25' stop-color='%23e5765e'/%3E%3C/linearGradient%3E%3ClinearGradient id='E' x1='91.59%25' x2='66.97%25' y1='5.89%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%23a22a50'/%3E%3Cstop offset='100%25' stop-color='%23ee7566'/%3E%3C/linearGradient%3E%3ClinearGradient id='F' x1='49.48%25' x2='49.61%25' y1='11.66%25' y2='98.34%25'%3E%3Cstop offset='0%25' stop-color='%23f7eab9'/%3E%3Cstop offset='100%25' stop-color='%23e5765e'/%3E%3C/linearGradient%3E%3ClinearGradient id='G' x1='78.5%25' x2='36.4%25' y1='106.76%25' y2='26.41%25'%3E%3Cstop offset='0%25' stop-color='%23a22a50'/%3E%3Cstop offset='100%25' stop-color='%23ee7566'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath fill='url(%23A)' d='M0 0h1024v1024H0z'/%3E%3Cuse fill='%23000' filter='url(%23C)' xlink:href='%23B'/%3E%3Cuse fill='%23fff6cb' xlink:href='%23B'/%3E%3Cg fill='%23fff' opacity='.3'%3E%3Ccircle cx='217' cy='278' r='3' fill-opacity='.4'/%3E%3Ccircle cx='96' cy='257' r='2'/%3E%3Ccircle cx='36' cy='287' r='2' opacity='.4'/%3E%3Ccircle cx='127' cy='88' r='3'/%3E%3Ccircle cx='216' cy='25' r='2'/%3E%3Ccircle cx='16' cy='137' r='2'/%3E%3Ccircle cx='166' cy='167' r='2'/%3E%3Ccircle cx='376' cy='247' r='2'/%3E%3Ccircle cx='467' cy='88' r='3' opacity='.4'/%3E%3Ccircle cx='527' cy='278' r='3'/%3E%3Ccircle cx='607' cy='138' r='3'/%3E%3Ccircle cx='817' cy='28' r='3' opacity='.4'/%3E%3Ccircle cx='516' cy='157' r='2'/%3E%3Ccircle cx='846' cy='227' r='2'/%3E%3Ccircle cx='766' cy='137' r='2'/%3E%3Ccircle cx='947' cy='278' r='3' opacity='.4'/%3E%3Ccircle cx='717' cy='248' r='3'/%3E%3Ccircle cx='917' cy='78' r='3'/%3E%3Ccircle cx='996' cy='167' r='2'/%3E%3Ccircle cx='646' cy='37' r='2'/%3E%3C/g%3E%3Cg transform='translate(0 550)'%3E%3Cpath fill='%238e2c15' d='M259 5.47c0 5.33 3.33 9.5 10 12.5s9.67 9.16 9 18.5h1c.67-6.31 1-11.8 1-16.47 8.67 0 13.33-1.33 14-4 .67 4.98 1.67 8.3 3 9.97 1.33 1.66 2 5.16 2 10.5h1c0-5.65.33-9.64 1-11.97 1-3.5 4-10.03-1-14.53S295 7 290 3s-10-3-13 2-5 7-9 7-5-3.53-5-5.53 2-5-1.5-5-7.5 0-7.5 2c0 1.33 1.67 2 5 2z'/%3E%3Cg fill='url(%23D)'%3E%3Cpath d='M1024 390H0V105.08C77.3 71.4 155.26 35 297.4 35c250 0 250.76 125.25 500 125 84.03-.08 160.02-18.2 226.6-40.93V390z'/%3E%3Cpath d='M1024 442H0V271.82c137.51-15.4 203.1-50.49 356.67-60.1C555.24 199.3 606.71 86.59 856.74 86.59c72.78 0 124.44 10.62 167.26 25.68V442z'/%3E%3C/g%3E%3Cg fill='url(%23E)'%3E%3Cpath d='M1024 112.21V412H856.91c99.31-86.5 112.63-140.75 39.97-162.78C710.24 192.64 795.12 86.58 856.9 86.58c72.7 0 124.3 10.6 167.09 25.63z'/%3E%3Cpath d='M1024 285.32V412H857c99.31-86.6 112.63-140.94 39.97-163L1024 285.32z'/%3E%3C/g%3E%3Cpath fill='url(%23F)' d='M0 474V223.93C67.12 190.69 129.55 155 263 155c250 0 331.46 162.6 530 175 107.42 6.71 163-26.77 231-58.92V474H0z'/%3E%3Cpath fill='url(%23E)' d='M353.02 474H0V223.93C67.12 190.69 129.55 155 263 155c71.14 0 151.5 12.76 151.5 70.5 0 54.5-45.5 79.72-112.5 109-82.26 35.95-54.57 111.68 51.02 139.5z'/%3E%3Cpath fill='url(%23G)' d='M353.02 474H0v-14.8l302-124.7c-82.26 35.95-54.57 111.68 51.02 139.5z'/%3E%3C/g%3E%3Cg fill='%23fff'%3E%3Cg opacity='.2'%3E%3Ccircle cx='538' cy='633' r='110'/%3E%3Ccircle cx='708' cy='601' r='60'/%3E%3Ccircle cx='358' cy='743' r='70'/%3E%3C/g%3E%3Cg fill-rule='nonzero' opacity='.08'%3E%3Cpath d='M145 396.22c5.536-5.491 14.464-5.491 20 0s14.464 5.491 20 0l20-19.86c16.603-16.484 43.397-16.484 60 0l15 14.9c8.304 8.237 21.696 8.237 30 0s21.696-8.237 30 0l.9.9A47.69 47.69 0 0 1 355 426H135v-5.76a33.84 33.84 0 0 1 10-24.02zm559.1-66.11l5.9-5.86c11.07-11 28.93-11 40 0l10 9.94c5.534 5.497 14.466 5.497 20 0s14.466-5.497 20 0a16.36 16.36 0 0 0 21.3 1.5l8.7-6.47c11.867-8.844 28.133-8.844 40 0l4.06 3.03A39.6 39.6 0 0 1 890 364H690a47.77 47.77 0 0 1 14.1-33.89z'/%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+      /* {{ else if eq code "503" }} */
+      /* https://github.com/LaravelCollective/errors/blob/8a0cf6fb73ba0041330967d3d6a137bd4509f7bd/src/publish/svg/503.svg */
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 1024 1024'%3E%3Cdefs%3E%3ClinearGradient id='A' x1='50.31%25' x2='50%25' y1='74.74%25' y2='0%25'%3E%3Cstop offset='0%25' stop-color='%23e26b6b'/%3E%3Cstop offset='50.28%25' stop-color='%23f5bcf4'/%3E%3Cstop offset='100%25' stop-color='%238690e1'/%3E%3C/linearGradient%3E%3ClinearGradient id='B' x1='50%25' x2='50%25' y1='0%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%238c9ce7'/%3E%3Cstop offset='100%25' stop-color='%234353a4'/%3E%3C/linearGradient%3E%3ClinearGradient id='C' x1='50%25' x2='50%25' y1='0%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%23d1d9ff'/%3E%3Cstop offset='100%25' stop-color='%238395eb'/%3E%3C/linearGradient%3E%3Ccircle id='D' cx='622' cy='663' r='60'/%3E%3Cfilter id='E' width='260%25' height='260%25' x='-80%25' y='-80%25'%3E%3CfeOffset in='SourceAlpha'/%3E%3CfeGaussianBlur stdDeviation='32'/%3E%3CfeColorMatrix values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0'/%3E%3C/filter%3E%3ClinearGradient id='F' x1='49.87%25' x2='49.87%25' y1='3.62%25' y2='77.75%25'%3E%3Cstop offset='0%25' stop-color='%23b0ddf1'/%3E%3Cstop offset='100%25' stop-color='%23325c82'/%3E%3C/linearGradient%3E%3ClinearGradient id='G' x1='100%25' x2='72.45%25' y1='0%25' y2='85.2%25'%3E%3Cstop offset='0%25' stop-color='%231d3a6d'/%3E%3Cstop offset='100%25' stop-color='%23467994'/%3E%3C/linearGradient%3E%3ClinearGradient id='H' x1='49.48%25' x2='49.87%25' y1='11.66%25' y2='77.75%25'%3E%3Cstop offset='0%25' stop-color='%23b9c9f7'/%3E%3Cstop offset='100%25' stop-color='%23301863'/%3E%3C/linearGradient%3E%3ClinearGradient id='I' x1='91.59%25' x2='70.98%25' y1='5.89%25' y2='88%25'%3E%3Cstop offset='0%25' stop-color='%232d3173'/%3E%3Cstop offset='100%25' stop-color='%237f90e0'/%3E%3C/linearGradient%3E%3ClinearGradient id='J' x1='70.98%25' x2='70.98%25' y1='9.88%25' y2='88%25'%3E%3Cstop offset='0%25' stop-color='%232d3173'/%3E%3Cstop offset='100%25' stop-color='%237f90e0'/%3E%3C/linearGradient%3E%3Cpath id='K' d='M251 506a8 8 0 0 1 8 8v15l-16 1v-16a8 8 0 0 1 8-8z'/%3E%3Cpath id='L' d='M253 506.25a8 8 0 0 0-6 7.75v15.75l-4 .25v-16a8 8 0 0 1 10-7.75z'/%3E%3C/defs%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath fill='url(%23A)' d='M0 0h1024v1024H0z'/%3E%3Cg transform='translate(211 420)'%3E%3Cpath fill='%238c9ce7' d='M65 0a2 2 0 0 1 2 2v23h-4V2c0-1.1.9-2 2-2z'/%3E%3Cpath fill='%235263b8' d='M64 24h2a3 3 0 0 1 3 3v2h-8v-2a3 3 0 0 1 3-3z'/%3E%3Cpath fill='url(%23B)' d='M65 108h40V68a40 40 0 1 0-80 0v40h40z'/%3E%3Cpath fill='%232e3d87' d='M0 118l30-6v106H0z'/%3E%3Cpath fill='%23301862' d='M60 118l-30-6v106h30z'/%3E%3Cpath fill='url(%23C)' d='M45 107V68a40.02 40.02 0 0 1 30.03-38.75C92.27 33.65 105 49.11 105 67.5V107H45z'/%3E%3Cpath fill='%234353a4' d='M15 78l50-10 2 2v108H15z'/%3E%3Cpath fill='%238c9ce7' d='M115 78L65 68v2 108h50z'/%3E%3Cpath fill='%234353a4' d='M75 118l30-6v106H75z'/%3E%3Cpath fill='%238c9ce7' d='M135 118l-30-6v106h30z'/%3E%3C/g%3E%3Cuse fill='%23000' filter='url(%23E)' xlink:href='%23D'/%3E%3Cuse fill='%23fff' xlink:href='%23D'/%3E%3Cg transform='translate(146 245)'%3E%3Cpath fill='url(%23F)' d='M169.12 450.57C192.22 464.04 143.85 532.52 24 656h649L169.12 450.57z'/%3E%3Cpath fill='url(%23G)' d='M178.5 538.5C137.83 567.17 199.67 606.33 364 656H0l178.5-117.5z'/%3E%3C/g%3E%3Cpath fill='url(%23H)' d='M1024 940H0V655.08C77.3 621.4 155.26 585 297.4 585c250 0 250.76 125.25 500 125 84.03-.08 160.02-18.2 226.6-40.93V940z'/%3E%3Cuse xlink:href='%23K' fill='%231f2a68'/%3E%3Cuse xlink:href='%23L' fill='%237c8cda'/%3E%3Cuse xlink:href='%23K' y='40' fill='%231f2a68'/%3E%3Cuse xlink:href='%23L' y='40' fill='%237c8cda'/%3E%3Cpath fill='%235263b8' d='M301 506a8 8 0 0 1 8 8v16l-16-1v-15a8 8 0 0 1 8-8z'/%3E%3Cpath fill='%23293781' d='M305 529.75V514a8 8 0 0 0-6-7.75 8.01 8.01 0 0 1 10 7.75v16l-4-.25z'/%3E%3Cg transform='translate(0 636)'%3E%3Cpath fill='url(%23H)' d='M1024 356H0V185.82c137.51-15.4 203.1-50.49 356.67-60.1C555.24 113.3 606.71.59 856.74.59 929.52.58 981.18 11.2 1024 26.26V356z'/%3E%3Cg fill='url(%23I)'%3E%3Cpath d='M1024 26.21V326H856.91c99.31-86.5 112.63-140.75 39.97-162.78C710.24 106.64 795.12.58 856.9.58c72.7 0 124.3 10.6 167.09 25.63z'/%3E%3Cpath d='M1024 199.32V326H857c99.31-86.6 112.63-140.94 39.97-163L1024 199.32z'/%3E%3C/g%3E%3C/g%3E%3Cg fill='%23fff'%3E%3Ccircle cx='566' cy='599' r='110' opacity='.1'/%3E%3Ccircle cx='669' cy='539' r='60' opacity='.1'/%3E%3C/g%3E%3Cg transform='translate(0 705)'%3E%3Cpath fill='url(%23H)' d='M0 319V68.93C67.12 35.69 129.55 0 263 0c250 0 331.46 162.6 530 175 107.42 6.71 163-26.77 231-58.92V319H0z'/%3E%3Cpath fill='url(%23I)' d='M353.02 319H0V68.93C67.12 35.69 129.55 0 263 0c71.14 0 151.5 12.76 151.5 70.5 0 54.5-45.5 79.72-112.5 109-82.26 35.95-54.57 111.68 51.02 139.5z'/%3E%3Cpath fill='url(%23J)' d='M353.02 319H0v-14.8l302-124.7c-82.26 35.95-54.57 111.68 51.02 139.5z'/%3E%3C/g%3E%3Cg fill='%23fff'%3E%3Ccircle cx='414' cy='799' r='70' opacity='.1'/%3E%3Ccircle cx='479' cy='745' r='30' opacity='.1'/%3E%3Cg opacity='.15'%3E%3Cpath d='M603.67 345.48a9.46 9.46 0 0 1 13.33 0 9.46 9.46 0 0 0 13.33 0l13.33-13.24c11.07-10.988 28.93-10.988 40 0l10 9.93c5.536 5.491 14.464 5.491 20 0s14.464-5.491 20 0l.6.6a31.8 31.8 0 0 1 9.4 22.56H597v-3.84c0-6.01 2.4-11.78 6.67-16.01zM800 222.25c11.07-11 28.93-11 40 0l10 9.94c5.534 5.497 14.466 5.497 20 0s14.466-5.497 20 0a16.36 16.36 0 0 0 21.3 1.5l8.7-6.47c11.867-8.844 28.133-8.844 40 0l4.06 3.03A39.6 39.6 0 0 1 980 262H780c0-12.72 8.93-28.75 20-39.75zM63.1 289.14l.9-.9c8.302-8.242 21.698-8.242 30 0s21.698 8.242 30 0l10-9.93c13.835-13.739 36.165-13.739 50 0l15 14.9c5.536 5.491 14.464 5.491 20 0s14.464-5.491 20 0a33.84 33.84 0 0 1 10 24.02V323H49c0-12.71 5.07-24.9 14.1-33.86z'/%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+      /* {{ else if eq code "403" }} */
+      /* https://github.com/LaravelCollective/errors/blob/8a0cf6fb73ba0041330967d3d6a137bd4509f7bd/src/publish/svg/403.svg */
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 1024 1024'%3E%3Cdefs%3E%3ClinearGradient id='A' x1='50%25' x2='50%25' y1='100%25' y2='0%25'%3E%3Cstop offset='0%25' stop-color='%2376c3c3'/%3E%3Cstop offset='100%25' stop-color='%23183468'/%3E%3C/linearGradient%3E%3ClinearGradient id='B' x1='100%25' x2='0%25' y1='50%25' y2='50%25'%3E%3Cstop offset='0%25' stop-color='%23486587'/%3E%3Cstop offset='33.23%25' stop-color='%23183352'/%3E%3Cstop offset='66.67%25' stop-color='%23264a6e'/%3E%3Cstop offset='100%25' stop-color='%23183352'/%3E%3C/linearGradient%3E%3ClinearGradient id='C' x1='49.87%25' x2='48.5%25' y1='3.62%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%23e0f2fa'/%3E%3Cstop offset='8.98%25' stop-color='%2389bed6'/%3E%3Cstop offset='32.98%25' stop-color='%231e3c6e'/%3E%3Cstop offset='100%25' stop-color='%231b376b'/%3E%3C/linearGradient%3E%3ClinearGradient id='D' x1='49.87%25' x2='49.87%25' y1='3.62%25' y2='77.75%25'%3E%3Cstop offset='0%25' stop-color='%23b0ddf1'/%3E%3Cstop offset='100%25' stop-color='%23325c82'/%3E%3C/linearGradient%3E%3ClinearGradient id='E' x1='91.59%25' x2='66.97%25' y1='5.89%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%231d3a6d'/%3E%3Cstop offset='100%25' stop-color='%23467994'/%3E%3C/linearGradient%3E%3ClinearGradient id='F' x1='97.27%25' x2='52.53%25' y1='6.88%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%231d3a6d'/%3E%3Cstop offset='100%25' stop-color='%23467994'/%3E%3C/linearGradient%3E%3ClinearGradient id='G' x1='82.73%25' x2='41.46%25' y1='41.06%25' y2='167.23%25'%3E%3Cstop offset='0%25' stop-color='%231d3a6d'/%3E%3Cstop offset='100%25' stop-color='%23467994'/%3E%3C/linearGradient%3E%3ClinearGradient id='H' x1='49.87%25' x2='49.87%25' y1='3.62%25' y2='100.77%25'%3E%3Cstop offset='0%25' stop-color='%23b0ddf1'/%3E%3Cstop offset='100%25' stop-color='%23325c82'/%3E%3C/linearGradient%3E%3ClinearGradient id='I' x1='100%25' x2='72.45%25' y1='0%25' y2='85.2%25'%3E%3Cstop offset='0%25' stop-color='%231d3a6d'/%3E%3Cstop offset='100%25' stop-color='%23467994'/%3E%3C/linearGradient%3E%3ClinearGradient id='J' x1='100%25' x2='62.1%25' y1='0%25' y2='68.86%25'%3E%3Cstop offset='0%25' stop-color='%23163055'/%3E%3Cstop offset='100%25' stop-color='%232f587f'/%3E%3C/linearGradient%3E%3Ccircle id='K' cx='180' cy='102' r='40'/%3E%3Cfilter id='L' width='340%25' height='340%25' x='-120%25' y='-120%25'%3E%3CfeOffset in='SourceAlpha'/%3E%3CfeGaussianBlur stdDeviation='32'/%3E%3CfeColorMatrix values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.696473053 0'/%3E%3C/filter%3E%3ClinearGradient id='M' x1='0%25' y1='50%25' y2='50%25'%3E%3Cstop offset='0%25' stop-color='%23fff' stop-opacity='0'/%3E%3Cstop offset='100%25' stop-color='%23fff'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath fill='url(%23A)' d='M0 0h1024v1024H0z'/%3E%3Cpath d='M857 508l4-1v11h-4zm-20-4l4-1v15h-4z' fill='%238dbcd2'/%3E%3Cg fill='%23183352'%3E%3Cpath d='M801 503l4 1v14h-4zm-20 4l4 1v14h-4z'/%3E%3Cpath opacity='.5' d='M820 481h2v20h-2z'/%3E%3C/g%3E%3Cpath fill='url(%23B)' d='M61 0c3 0 3 2 6 2s3-2 6-2 3 2 6 2v8c-3 0-3-2-6-2s-3 2-6 2-3-2-6-2V0z' transform='translate(761 481)'/%3E%3Cpath fill='%238dbcd2' d='M811 501l10-2v110h-60l10-100 10-2v10.92l10-.98V505l10-2v12.96l10-.98V501z'/%3E%3Cpath fill='%23183352' d='M861 507l10 2 10 100h-60V499l10 2v13.98l10 .98V503l10 2v11.94l10 .98V507z'/%3E%3Cg transform='translate(0 565)'%3E%3Cpath fill='url(%23C)' d='M1024 385H0V106.86c118.4 21.09 185.14 57.03 327.4 48.14 198.54-12.4 250-125 500-125 90.18 0 147.92 16.3 196.6 37.12V385z'/%3E%3Cg fill='url(%23D)'%3E%3Cpath d='M1024 355H0V79.56C76.46 43.81 137.14 0 285 0c250 0 301.46 112.6 500 125 103.24 6.45 166.7-10.7 239-28.66V355z'/%3E%3Cpath d='M344.12 130.57C367.22 144.04 318.85 212.52 199 336h649L344.12 130.57z'/%3E%3C/g%3E%3Cpath fill='url(%23E)' d='M0 336V79.56C76.46 43.81 137.14 0 285 0c71.14 0 86.22 26.04 32.5 82-48 50 147.33 58.02 36 136.5-40.67 28.67 21.17 67.83 185.5 117.5H0z'/%3E%3Cpath fill='url(%23F)' d='M317.5 82c-48 50 147.33 58.02 36 136.5-40.67 28.67 21.17 67.83 185.5 117.5H55L317.5 82z'/%3E%3Cpath fill='url(%23G)' d='M353.5 218.5C312.83 247.17 374.67 286.33 539 336H175l178.5-117.5z'/%3E%3Cpath fill='url(%23H)' d='M0 459V264.54c100.25 21.2 167.18 50.29 296.67 42.19 198.57-12.43 250.04-125.15 500.07-125.15 109.75 0 171.47 24.16 227.26 51.25V459H0z'/%3E%3Cpath fill='url(%23I)' d='M1024 459H846.16c51.95-58.9 48.86-97.16-9.28-114.78-186.64-56.58-101.76-162.64-39.97-162.64 109.64 0 171.34 24.12 227.09 51.19V459z'/%3E%3Cpath fill='url(%23J)' d='M1024 459H846.19c52.01-59.01 48.94-97.34-9.22-115L1024 397.48V459z'/%3E%3C/g%3E%3Cg transform='translate(94 23)'%3E%3Cuse fill='%23000' filter='url(%23L)' xlink:href='%23K'/%3E%3Cuse fill='%23d2f1fe' xlink:href='%23K'/%3E%3Cg fill='%23fff'%3E%3Ccircle cx='123' cy='255' r='3' fill-opacity='.4'/%3E%3Ccircle cx='2' cy='234' r='2'/%3E%3Ccircle cx='33' cy='65' r='3'/%3E%3Ccircle cx='122' cy='2' r='2'/%3E%3Ccircle cx='72' cy='144' r='2'/%3E%3Ccircle cx='282' cy='224' r='2'/%3E%3Ccircle cx='373' cy='65' r='3' opacity='.4'/%3E%3Ccircle cx='433' cy='255' r='3'/%3E%3C/g%3E%3Cpath fill='url(%23M)' d='M373.25 325.25a5 5 0 0 0 0-10h-75v10h75z' opacity='.4' transform='rotate(45 338.251 320.251)'/%3E%3Cg fill='%23fff'%3E%3Ccircle cx='363' cy='345' r='3'/%3E%3Ccircle cx='513' cy='115' r='3'/%3E%3Ccircle cx='723' cy='5' r='3' opacity='.4'/%3E%3Ccircle cx='422' cy='134' r='2'/%3E%3Ccircle cx='752' cy='204' r='2'/%3E%3Ccircle cx='672' cy='114' r='2'/%3E%3Ccircle cx='853' cy='255' r='3' opacity='.4'/%3E%3Ccircle cx='623' cy='225' r='3'/%3E%3Ccircle cx='823' cy='55' r='3'/%3E%3Ccircle cx='902' cy='144' r='2'/%3E%3Ccircle cx='552' cy='14' r='2'/%3E%3C/g%3E%3C/g%3E%3Cpath fill='%23486587' d='M796 535a4 4 0 0 1 4 4v20h-8v-20a4 4 0 0 1 4-4z'/%3E%3Cpath fill='%23071423' d='M798 535.54a4 4 0 0 0-2 3.46v20h-4v-20a4 4 0 0 1 6-3.46zm48-.54a4 4 0 0 1 4 4v20h-8v-20a4 4 0 0 1 4-4z'/%3E%3Cpath fill='%238dbcd2' d='M846 559v-20a4 4 0 0 0-2-3.46 4 4 0 0 1 6 3.46v20h-4z'/%3E%3Cg fill='%23fff' opacity='.07'%3E%3Cpath d='M608.67 432.48a9.46 9.46 0 0 1 13.33 0 9.46 9.46 0 0 0 13.33 0l13.33-13.24c11.07-10.988 28.93-10.988 40 0l10 9.93c5.536 5.491 14.464 5.491 20 0s14.464-5.491 20 0l.6.6a31.8 31.8 0 0 1 9.4 22.56H602v-3.84c0-6.01 2.4-11.78 6.67-16.01zM805 309.25c11.07-11 28.93-11 40 0l10 9.94c5.534 5.497 14.466 5.497 20 0s14.466-5.497 20 0a16.36 16.36 0 0 0 21.3 1.5l8.7-6.47c11.867-8.844 28.133-8.844 40 0l4.06 3.03A39.6 39.6 0 0 1 985 349H785c0-12.72 8.93-28.75 20-39.75zM68.1 376.14l.9-.9c8.302-8.242 21.698-8.242 30 0s21.698 8.242 30 0l10-9.93c13.835-13.739 36.165-13.739 50 0l15 14.9c5.536 5.491 14.464 5.491 20 0s14.464-5.491 20 0a33.84 33.84 0 0 1 10 24.02V410H54c0-12.71 5.07-24.9 14.1-33.86z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+      /* {{ else }} */
+      /* https://github.com/LaravelCollective/errors/blob/8a0cf6fb73ba0041330967d3d6a137bd4509f7bd/src/publish/svg/500.svg */
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 1024 1024'%3E%3Cdefs%3E%3ClinearGradient id='a' x1='50%25' x2='50%25' y1='100%25' y2='0%25'%3E%3Cstop offset='0%25' stop-color='%23F6EDAE'/%3E%3Cstop offset='100%25' stop-color='%2391D4D7'/%3E%3C/linearGradient%3E%3ClinearGradient id='b' x1='49.87%25' x2='49.87%25' y1='3.62%25' y2='77.75%25'%3E%3Cstop offset='0%25' stop-color='%23B0DDF1'/%3E%3Cstop offset='100%25' stop-color='%23325C82'/%3E%3C/linearGradient%3E%3ClinearGradient id='c' x1='100%25' x2='72.45%25' y1='0%25' y2='85.2%25'%3E%3Cstop offset='0%25' stop-color='%231D3A6D'/%3E%3Cstop offset='100%25' stop-color='%23467994'/%3E%3C/linearGradient%3E%3ClinearGradient id='d' x1='54.81%25' x2='50%25' y1='-18.48%25' y2='59.98%25'%3E%3Cstop offset='0%25' stop-color='%23FFFFFF'/%3E%3Cstop offset='28.15%25' stop-color='%23F8E6B3'/%3E%3Cstop offset='100%25' stop-color='%23D5812F'/%3E%3C/linearGradient%3E%3ClinearGradient id='e' x1='52.84%25' x2='49.87%25' y1='2.8%25' y2='77.75%25'%3E%3Cstop offset='0%25' stop-color='%23FFFFFF'/%3E%3Cstop offset='22.15%25' stop-color='%23F8E6B3'/%3E%3Cstop offset='100%25' stop-color='%23F9D989'/%3E%3C/linearGradient%3E%3ClinearGradient id='f' x1='91.59%25' x2='66.97%25' y1='5.89%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%23CE4014'/%3E%3Cstop offset='100%25' stop-color='%23FFD56E'/%3E%3C/linearGradient%3E%3ClinearGradient id='g' x1='40.28%25' x2='66.37%25' y1='30.88%25' y2='108.51%25'%3E%3Cstop offset='0%25' stop-color='%23A2491E'/%3E%3Cstop offset='100%25' stop-color='%23F4B35A'/%3E%3C/linearGradient%3E%3Ccircle id='i' cx='825' cy='235' r='70'/%3E%3Cfilter id='h' width='237.1%25' height='237.1%25' x='-68.6%25' y='-68.6%25' filterUnits='objectBoundingBox'%3E%3CfeOffset in='SourceAlpha' result='shadowOffsetOuter1'/%3E%3CfeGaussianBlur in='shadowOffsetOuter1' result='shadowBlurOuter1' stdDeviation='32'/%3E%3CfeColorMatrix in='shadowBlurOuter1' values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0'/%3E%3C/filter%3E%3ClinearGradient id='j' x1='50%25' x2='50%25' y1='0%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%23B29959'/%3E%3Cstop offset='100%25' stop-color='%23CEAD5B'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Crect width='1024' height='1024' fill='url(%23a)'/%3E%3Cpath fill='%23FFFFFF' d='M1024 378.13v39.37H790a71.59 71.59 0 0 1 21.14-50.8l1.36-1.34a31.93 31.93 0 0 1 45 0 31.93 31.93 0 0 0 45 0l15-14.9a53.21 53.21 0 0 1 75 0l22.5 22.35a21.2 21.2 0 0 0 9 5.32z' opacity='.15'/%3E%3Cg transform='translate(26 245)'%3E%3Cpath fill='url(%23b)' d='M289.12 450.57C312.22 464.04 263.85 532.52 144 656h649C448.94 514.3 280.98 445.83 289.12 450.57z'/%3E%3Cpath fill='url(%23c)' d='M262.5 402c-48 50 147.33 58.02 36 136.5-40.67 28.67 21.17 67.83 185.5 117.5H0l262.5-254z'/%3E%3Cpath fill='url(%23c)' d='M298.5 538.5C257.83 567.17 319.67 606.33 484 656H120l178.5-117.5z'/%3E%3C/g%3E%3Cpath fill='%23134F4E' d='M783 593.73a29.95 29.95 0 0 1-12-24c0-9.8 4.72-18.52 12-24-5.02 6.69-8 15-8 24 0 9.01 2.98 17.32 8 24z'/%3E%3Cg fill='%23134F4E' transform='matrix(-1 0 0 1 876 532)'%3E%3Cpath d='M24 66.73a29.95 29.95 0 0 1-12-24c0-9.8 4.72-18.52 12-24-5.02 6.69-8 15-8 24 0 9.01 2.98 17.32 8 24z'/%3E%3Cpath d='M36 22.4l-3.96-3.98a5 5 0 0 0-6.5-.5 3 3 0 0 1 3.7-3.55l8.7 2.33a8 8 0 0 1 5.66 9.8l-1-1.73a2 2 0 0 0-1.21-.93L36 22.4zm-5.38-2.56L37 26.2a8 8 0 0 1 0 11.32v-2a2 2 0 0 0-.6-1.42L26.39 24.08a3 3 0 0 1 4.24-4.24zM14.21 9.8l-3.94-3.94a2 2 0 0 0-1.42-.59h-2a8 8 0 0 1 11.32 0l6.36 6.37a3 3 0 0 1-1.22 4.98 5 5 0 0 0-3.68-5.37l-5.42-1.45zm4.9 3.39a3 3 0 1 1-1.55 5.8L3.87 15.31a2 2 0 0 0-1.52.2l-1.73 1a8 8 0 0 1 9.8-5.65l8.7 2.33z'/%3E%3C/g%3E%3Cg transform='translate(0 245)'%3E%3Cpath fill='url(%23d)' d='M1024 423.16V645H58.09c-32.12-75.17-32.12-123.84 0-146 48.17-33.24 127.17-64.25 293.33-64 166.17.25 246.67-105 413.33-105 117.33 0 183.93 55.8 259.25 93.16z'/%3E%3Cpath fill='url(%23e)' d='M1024 778H0V398.62C75.53 363.05 136.43 320 283 320c111.86 0 358.86 69.82 741 209.47V778z'/%3E%3Cpath fill='url(%23f)' d='M0 778V398.62C75.53 363.05 136.43 320 283 320c71.14 0 85.96 26.04 32.5 82-79.5 83.22 279.7 2.01 336 131.5 26 59.8-69.83 141.3-287.48 244.5H0z'/%3E%3Cpath fill='url(%23g)' d='M364.02 778H0V638.4L315.5 402c-79.5 83.22 279.7 2.01 336 131.5 26 59.8-69.83 141.3-287.48 244.5z'/%3E%3C/g%3E%3Cpath fill='%23134F4E' d='M795 549.4l-3.96-3.98a5 5 0 0 0-6.5-.5 3 3 0 0 1 3.7-3.55l8.7 2.33a8 8 0 0 1 5.66 9.8l-1-1.73a2 2 0 0 0-1.21-.93L795 549.4zm-5.38-2.56l6.37 6.36a8 8 0 0 1 0 11.32v-2a2 2 0 0 0-.6-1.42l-10.01-10.02a3 3 0 0 1 4.24-4.24zm-16.41-10.03l-3.94-3.94a2 2 0 0 0-1.42-.59h-2a8 8 0 0 1 11.32 0l6.36 6.37a3 3 0 0 1-1.22 4.98 5 5 0 0 0-3.68-5.37l-5.42-1.45zm4.9 3.39a3 3 0 1 1-1.55 5.8l-13.69-3.68a2 2 0 0 0-1.52.2l-1.73 1a8 8 0 0 1 9.8-5.65l8.7 2.33z'/%3E%3Cpath fill='%23FFFFFF' d='M395.67 116.48a9.46 9.46 0 0 1 13.33 0 9.46 9.46 0 0 0 13.33 0l13.33-13.24a28.39 28.39 0 0 1 40 0l10 9.93a14.2 14.2 0 0 0 20 0 14.2 14.2 0 0 1 20 0l.6.6a31.8 31.8 0 0 1 9.4 22.56H389v-3.84c0-6.01 2.4-11.78 6.67-16.01zM98.1 249.1l5.9-5.86c11.07-11 28.93-11 40 0l10 9.94a14.19 14.19 0 0 0 20 0 14.19 14.19 0 0 1 20 0 16.36 16.36 0 0 0 21.3 1.5l8.7-6.47a33.47 33.47 0 0 1 40 0l4.06 3.03A39.6 39.6 0 0 1 284 283H84a47.77 47.77 0 0 1 14.1-33.89z' opacity='.15'/%3E%3Cuse fill='black' filter='url(%23h)' xlink:href='%23i'/%3E%3Cuse fill='%23FFFFFF' xlink:href='%23i'/%3E%3Cpath fill='%23FFFFFF' d='M702.69 960.64a4.32 4.32 0 0 1-1.04 6.87c-2.26 1.2-3.69 2.1-4.27 2.67-.51.52-1.17 1.4-1.97 2.62a3.53 3.53 0 0 1-5.45.56 3.53 3.53 0 0 1 .56-5.44c1.23-.8 2.1-1.46 2.62-1.98.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.88-1.03z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M700.32 962a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25a3.53 3.53 0 0 1-3.45 4.25 3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9a4.32 4.32 0 0 1 4.13-5.6z' transform='rotate(45 700.323 971)'/%3E%3Cg transform='rotate(-15 3943.802 -2244.376)'%3E%3Cpath fill='%23FFFFFF' d='M16.65 3.9a4.32 4.32 0 0 1-1.03 6.87c-2.27 1.2-3.7 2.1-4.27 2.67-.52.52-1.18 1.4-1.98 2.62a3.53 3.53 0 0 1-5.44.56 3.53 3.53 0 0 1 .56-5.44c1.23-.8 2.1-1.46 2.62-1.98.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.87-1.03z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M13.32 5a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 13.32 23a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 13.32 5z' transform='rotate(45 13.323 14)'/%3E%3C/g%3E%3Cg transform='rotate(-15 4117.1 -2152.014)'%3E%3Cpath fill='%23FFFFFF' d='M16.65 3.9a4.32 4.32 0 0 1-1.03 6.87c-2.27 1.2-3.7 2.1-4.27 2.67-.52.52-1.18 1.4-1.98 2.62a3.53 3.53 0 0 1-5.44.56 3.53 3.53 0 0 1 .56-5.44c1.23-.8 2.1-1.46 2.62-1.98.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.87-1.03z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M13.32 5a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 13.32 23a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 13.32 5z' transform='rotate(45 13.323 14)'/%3E%3C/g%3E%3Cg transform='rotate(-15 4127.186 -2023.184)'%3E%3Cpath fill='%23FFFFFF' d='M16.65 3.9a4.32 4.32 0 0 1-1.03 6.87c-2.27 1.2-3.7 2.1-4.27 2.67-.52.52-1.18 1.4-1.98 2.62a3.53 3.53 0 0 1-5.44.56 3.53 3.53 0 0 1 .56-5.44c1.23-.8 2.1-1.46 2.62-1.98.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.87-1.03z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M13.32 5a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 13.32 23a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 13.32 5z' transform='rotate(45 13.323 14)'/%3E%3C/g%3E%3Cg transform='rotate(-30 2055.753 -866.842)'%3E%3Cpath fill='%23FFFFFF' d='M16.55 3.4a4.32 4.32 0 0 1-1.03 6.88c-2.27 1.2-3.7 2.1-4.27 2.67-.52.52-1.18 1.39-1.98 2.62a3.53 3.53 0 0 1-5.44.56 3.53 3.53 0 0 1 .56-5.44c1.23-.8 2.1-1.46 2.62-1.98.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.87-1.04z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M12.32 6a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 12.32 24a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 12.32 6z' transform='rotate(45 12.323 15)'/%3E%3C/g%3E%3Cg transform='rotate(-30 2046.995 -931.189)'%3E%3Cpath fill='%23FFFFFF' d='M16.55 3.4a4.32 4.32 0 0 1-1.03 6.88c-2.27 1.2-3.7 2.1-4.27 2.67-.52.52-1.18 1.39-1.98 2.62a3.53 3.53 0 0 1-5.44.56 3.53 3.53 0 0 1 .56-5.44c1.23-.8 2.1-1.46 2.62-1.98.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.87-1.04z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M12.32 6a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 12.32 24a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 12.32 6z' transform='rotate(45 12.323 15)'/%3E%3C/g%3E%3Cg transform='rotate(-45 1406.147 -409.132)'%3E%3Cpath fill='%23FFFFFF' d='M16.93 3.22a4.32 4.32 0 0 1-1.03 6.88c-2.27 1.2-3.7 2.09-4.27 2.67-.52.52-1.18 1.39-1.98 2.61a3.53 3.53 0 0 1-5.45.57 3.53 3.53 0 0 1 .57-5.45c1.22-.8 2.1-1.46 2.61-1.97.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.88-1.04z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M10.32 6a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 10.32 24a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 10.32 6z' transform='rotate(45 10.323 15)'/%3E%3C/g%3E%3Cg transform='rotate(-24 2389.63 -1296.285)'%3E%3Cpath fill='%23FFFFFF' d='M16.93 3.22a4.32 4.32 0 0 1-1.03 6.88c-2.27 1.2-3.7 2.09-4.27 2.67-.52.52-1.18 1.39-1.98 2.61a3.53 3.53 0 0 1-5.45.57 3.53 3.53 0 0 1 .57-5.45c1.22-.8 2.1-1.46 2.61-1.97.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.88-1.04z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M10.32 6a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 10.32 24a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 10.32 6z' transform='rotate(45 10.323 15)'/%3E%3C/g%3E%3Cg transform='rotate(-50 1258.425 -353.155)'%3E%3Cpath fill='%23FFFFFF' d='M16.93 3.22a4.32 4.32 0 0 1-1.03 6.88c-2.27 1.2-3.7 2.09-4.27 2.67-.52.52-1.18 1.39-1.98 2.61a3.53 3.53 0 0 1-5.45.57 3.53 3.53 0 0 1 .57-5.45c1.22-.8 2.1-1.46 2.61-1.97.58-.58 1.47-2 2.67-4.27a4.32 4.32 0 0 1 6.88-1.04z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M10.32 6a4.32 4.32 0 0 1 4.13 5.6c-.75 2.45-1.13 4.08-1.13 4.9 0 .73.15 1.81.45 3.25A3.53 3.53 0 0 1 10.32 24a3.53 3.53 0 0 1-3.45-4.25c.3-1.44.45-2.52.45-3.25 0-.82-.37-2.45-1.13-4.9A4.32 4.32 0 0 1 10.32 6z' transform='rotate(45 10.323 15)'/%3E%3C/g%3E%3Cg transform='rotate(-35 1652.744 -777.703)'%3E%3Cpath fill='%23FFFFFF' d='M16.08 3.06a4.1 4.1 0 0 1-.98 6.53c-2.15 1.14-3.5 1.99-4.05 2.54-.5.5-1.12 1.32-1.88 2.49a3.35 3.35 0 0 1-5.18.53 3.35 3.35 0 0 1 .54-5.17c1.16-.76 2-1.39 2.48-1.88.55-.55 1.4-1.9 2.54-4.06a4.1 4.1 0 0 1 6.53-.98z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M9.8 5.7a4.1 4.1 0 0 1 3.93 5.31c-.71 2.33-1.07 3.89-1.07 4.67 0 .69.14 1.72.43 3.08A3.35 3.35 0 0 1 9.8 22.8a3.35 3.35 0 0 1-3.28-4.04c.28-1.36.43-2.39.43-3.09 0-.77-.36-2.33-1.08-4.66A4.1 4.1 0 0 1 9.81 5.7z' transform='rotate(45 9.807 14.25)'/%3E%3C/g%3E%3Cg transform='rotate(-35 1605.77 -758.112)'%3E%3Cpath fill='%23FFFFFF' d='M15.24 2.9a3.89 3.89 0 0 1-.93 6.19c-2.04 1.08-3.33 1.88-3.85 2.4a15.6 15.6 0 0 0-1.78 2.36 3.17 3.17 0 0 1-4.9.5 3.17 3.17 0 0 1 .51-4.9 15.6 15.6 0 0 0 2.36-1.78c.52-.52 1.32-1.8 2.4-3.84a3.89 3.89 0 0 1 6.19-.93z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M9.3 5.4a3.89 3.89 0 0 1 3.7 5.03c-.67 2.21-1 3.68-1 4.42 0 .66.13 1.63.4 2.92a3.17 3.17 0 0 1-3.1 3.83 3.17 3.17 0 0 1-3.12-3.83c.28-1.29.41-2.26.41-2.92 0-.74-.34-2.2-1.02-4.42A3.89 3.89 0 0 1 9.3 5.4z' transform='rotate(45 9.29 13.5)'/%3E%3C/g%3E%3Cg transform='rotate(-35 1591.812 -807.843)'%3E%3Cpath fill='%23FFFFFF' d='M15.24 2.9a3.89 3.89 0 0 1-.93 6.19c-2.04 1.08-3.33 1.88-3.85 2.4a15.6 15.6 0 0 0-1.78 2.36 3.17 3.17 0 0 1-4.9.5 3.17 3.17 0 0 1 .51-4.9 15.6 15.6 0 0 0 2.36-1.78c.52-.52 1.32-1.8 2.4-3.84a3.89 3.89 0 0 1 6.19-.93z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M9.3 5.4a3.89 3.89 0 0 1 3.7 5.03c-.67 2.21-1 3.68-1 4.42 0 .66.13 1.63.4 2.92a3.17 3.17 0 0 1-3.1 3.83 3.17 3.17 0 0 1-3.12-3.83c.28-1.29.41-2.26.41-2.92 0-.74-.34-2.2-1.02-4.42A3.89 3.89 0 0 1 9.3 5.4z' transform='rotate(45 9.29 13.5)'/%3E%3C/g%3E%3Cg transform='rotate(-44 1287.793 -536.004)'%3E%3Cpath fill='%23FFFFFF' d='M15.24 2.9a3.89 3.89 0 0 1-.93 6.19c-2.04 1.08-3.33 1.88-3.85 2.4a15.6 15.6 0 0 0-1.78 2.36 3.17 3.17 0 0 1-4.9.5 3.17 3.17 0 0 1 .51-4.9 15.6 15.6 0 0 0 2.36-1.78c.52-.52 1.32-1.8 2.4-3.84a3.89 3.89 0 0 1 6.19-.93z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M9.3 5.4a3.89 3.89 0 0 1 3.7 5.03c-.67 2.21-1 3.68-1 4.42 0 .66.13 1.63.4 2.92a3.17 3.17 0 0 1-3.1 3.83 3.17 3.17 0 0 1-3.12-3.83c.28-1.29.41-2.26.41-2.92 0-.74-.34-2.2-1.02-4.42A3.89 3.89 0 0 1 9.3 5.4z' transform='rotate(45 9.29 13.5)'/%3E%3C/g%3E%3Cg transform='rotate(-28 1831.874 -1151.097)'%3E%3Cpath fill='%23FFFFFF' d='M15.24 2.9a3.89 3.89 0 0 1-.93 6.19c-2.04 1.08-3.33 1.88-3.85 2.4a15.6 15.6 0 0 0-1.78 2.36 3.17 3.17 0 0 1-4.9.5 3.17 3.17 0 0 1 .51-4.9 15.6 15.6 0 0 0 2.36-1.78c.52-.52 1.32-1.8 2.4-3.84a3.89 3.89 0 0 1 6.19-.93z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M9.3 5.4a3.89 3.89 0 0 1 3.7 5.03c-.67 2.21-1 3.68-1 4.42 0 .66.13 1.63.4 2.92a3.17 3.17 0 0 1-3.1 3.83 3.17 3.17 0 0 1-3.12-3.83c.28-1.29.41-2.26.41-2.92 0-.74-.34-2.2-1.02-4.42A3.89 3.89 0 0 1 9.3 5.4z' transform='rotate(45 9.29 13.5)'/%3E%3C/g%3E%3Cg transform='rotate(-41 1316.639 -621.138)'%3E%3Cpath fill='%23FFFFFF' d='M13.54 2.58a3.46 3.46 0 0 1-.82 5.5A17.18 17.18 0 0 0 9.3 10.2c-.41.42-.94 1.12-1.58 2.1a2.82 2.82 0 0 1-4.36.45 2.82 2.82 0 0 1 .45-4.36c.99-.64 1.68-1.17 2.1-1.58.46-.46 1.17-1.6 2.13-3.42a3.46 3.46 0 0 1 5.5-.82z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M8.26 4.8a3.46 3.46 0 0 1 3.3 4.47c-.6 1.97-.9 3.27-.9 3.93 0 .59.12 1.45.36 2.6a2.82 2.82 0 0 1-2.76 3.4 2.82 2.82 0 0 1-2.76-3.4c.24-1.15.36-2.01.36-2.6 0-.66-.3-1.96-.9-3.93a3.46 3.46 0 0 1 3.3-4.47z' transform='rotate(45 8.258 12)'/%3E%3C/g%3E%3Cg transform='rotate(-41 1286.706 -646.924)'%3E%3Cpath fill='%23FFFFFF' d='M11.85 2.26a3.03 3.03 0 0 1-.72 4.8 15.04 15.04 0 0 0-3 1.88c-.35.36-.82.97-1.38 1.83a2.47 2.47 0 0 1-3.8.4 2.47 2.47 0 0 1 .39-3.82C4.2 6.8 4.8 6.33 5.17 5.97c.4-.4 1.03-1.4 1.87-3a3.03 3.03 0 0 1 4.81-.71z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M7.23 4.2a3.03 3.03 0 0 1 2.89 3.91c-.53 1.72-.8 2.87-.8 3.44 0 .51.11 1.27.32 2.27a2.47 2.47 0 0 1-2.41 2.98 2.47 2.47 0 0 1-2.42-2.98c.21-1 .32-1.76.32-2.27 0-.57-.27-1.72-.8-3.44a3.03 3.03 0 0 1 2.9-3.91z' transform='rotate(45 7.226 10.5)'/%3E%3C/g%3E%3Cg transform='rotate(-24 2011.85 -1427.831)'%3E%3Cpath fill='%23FFFFFF' d='M13.54 2.58a3.46 3.46 0 0 1-.82 5.5A17.18 17.18 0 0 0 9.3 10.2c-.41.42-.94 1.12-1.58 2.1a2.82 2.82 0 0 1-4.36.45 2.82 2.82 0 0 1 .45-4.36c.99-.64 1.68-1.17 2.1-1.58.46-.46 1.17-1.6 2.13-3.42a3.46 3.46 0 0 1 5.5-.82z' opacity='.6'/%3E%3Cpath fill='url(%23j)' d='M8.26 4.8a3.46 3.46 0 0 1 3.3 4.47c-.6 1.97-.9 3.27-.9 3.93 0 .59.12 1.45.36 2.6a2.82 2.82 0 0 1-2.76 3.4 2.82 2.82 0 0 1-2.76-3.4c.24-1.15.36-2.01.36-2.6 0-.66-.3-1.96-.9-3.93a3.46 3.46 0 0 1 3.3-4.47z' transform='rotate(45 8.258 12)'/%3E%3C/g%3E%3Ccircle cx='756' cy='209' r='110' fill='%23FFFFFF' opacity='.2'/%3E%3Ccircle cx='859' cy='139' r='40' fill='%23FFFFFF' opacity='.2'/%3E%3Ccircle cx='551' cy='383' r='70' fill='%23FFFFFF' opacity='.2'/%3E%3Ccircle cx='666' cy='359' r='30' fill='%23FFFFFF' opacity='.2'/%3E%3Crect width='60' height='6' x='722' y='547' fill='%23FFFFFF' opacity='.4' rx='3'/%3E%3Crect width='60' height='6' x='842' y='565' fill='%23FFFFFF' opacity='.4' rx='3'/%3E%3Crect width='40' height='6' x='762' y='559' fill='%23FFFFFF' opacity='.4' rx='3'/%3E%3Crect width='40' height='6' x='872' y='553' fill='%23FFFFFF' opacity='.4' rx='3'/%3E%3Crect width='40' height='6' x='811' y='547' fill='%23FFFFFF' opacity='.4' rx='3'/%3E%3C/g%3E%3C/svg%3E");
+      /* {{ end }} */
+    }
+
+    /* {{ if show_details }} */
+    .details {
+      font-size: 0;
+      color: var(--color-text-secondary);
+    }
+
+    .details table {
+      width: 100%;
+    }
+
+    .details td {
+      white-space: nowrap;
+      font-size: 11px;
+    }
+
+    .details .name {
+      text-align: right;
+      padding-right: .4em;
+      width: 10%;
+    }
+
+    .details .value {
+      text-align: left;
+      padding-left: .4em;
+      font-family: 'Lucida Console', 'Courier New', monospace;
+    }
+
+    /* {{ end }} */
+
+    @media (min-width: 768px) {
+      main {
+        flex-direction: row;
+      }
+
+      main .left, main .right {
+        width: 50%;
+      }
+
+      main .left {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      main .left .container .code {
+        font-size: 9rem;
+      }
+
+      main .left .container .space {
+        margin-top: 1.5rem;
+        margin-bottom: 1.5rem;
+      }
+
+      main .left .container .description {
+        font-size: 1.875rem;
+        font-weight: 300;
+        line-height: 1.5;
+      }
+
+      main .right {
+        display: flex;
+        padding-bottom: 0;
+        min-height: 100vh;
+      }
+
+      main .right .container {
+        background-position: left;
+      }
+    }
+
+    @media (min-width: 992px) {
+      main .right .container {
+        background-position: center;
+      }
+    }
+  </style>
 </head>
-<body class="antialiased font-sans">
-    <div class="md:flex min-h-screen">
-        <div class="w-full md:w-1/2 bg-white flex items-center justify-center">
-            <div class="max-w-sm m-8">
-                <div class="text-black text-5xl md:text-15xl font-black">
-                  {{ code }}
-                </div>
-
-                <div class="w-16 h-1 bg-purple-light my-3 md:my-6"></div>
-
-                <p class="text-grey-darker text-2xl md:text-3xl font-light mb-8 leading-normal">
-                  {{ description  }}
-                </p>
-            </div>
-        </div>
-
-        <div class="relative pb-full md:flex md:pb-0 md:min-h-screen w-full md:w-1/2">
-            <div id=bg-canvas class="absolute pin bg-cover bg-no-repeat md:bg-left lg:bg-center">
-            </div>
-        </div>
+<body>
+<main>
+  <div class="left">
+    <div class="container">
+      <div class="code">{{ code }}</div>
+      <div class="space"></div>
+      <p class="description" data-l10n>{{ description }}</p>
+      <!-- {{ if show_details }} -->
+      <div class="details">
+        <table>
+          {{- if host }}
+          <tr>
+            <td class="name" data-l10n>Host</td>
+            <td class="value">{{ host }}</td>
+          </tr>
+          {{ end -}}
+          {{- if original_uri }}
+          <tr>
+            <td class="name" data-l10n>Original URI</td>
+            <td class="value">{{ original_uri }}</td>
+          </tr>
+          {{ end -}}
+          {{- if forwarded_for }}
+          <tr>
+            <td class="name" data-l10n>Forwarded for</td>
+            <td class="value">{{ forwarded_for }}</td>
+          </tr>
+          {{ end -}}
+          {{- if namespace }}
+          <tr>
+            <td class="name" data-l10n>Namespace</td>
+            <td class="value">{{ namespace }}</td>
+          </tr>
+          {{ end -}}
+          {{- if ingress_name }}
+          <tr>
+            <td class="name" data-l10n>Ingress name</td>
+            <td class="value">{{ ingress_name }}</td>
+          </tr>
+          {{ end -}}
+          {{- if service_name }}
+          <tr>
+            <td class="name" data-l10n>Service name</td>
+            <td class="value">{{ service_name }}</td>
+          </tr>
+          {{ end -}}
+          {{- if service_port }}
+          <tr>
+            <td class="name" data-l10n>Service port</td>
+            <td class="value">{{ service_port }}</td>
+          </tr>
+          {{ end -}}
+          {{- if request_id }}
+          <tr>
+            <td class="name" data-l10n>Request ID</td>
+            <td class="value">{{ request_id }}</td>
+          </tr>
+          {{ end -}}
+          <tr>
+            <td class="name" data-l10n>Timestamp</td>
+            <td class="value">{{ now.Unix }}</td>
+          </tr>
+        </table>
+      </div>
+      <!-- {{ end }} -->
     </div>
+  </div>
+  <div class="right">
+    <div class="container"></div>
+  </div>
+</main>
 
 <script>
-    // set random background
-    var allBackgrounds = ['bg-morning','bg-day','bg-evening', 'bg-night'];
-    var randomBackground = Math.floor(Math.random() * allBackgrounds.length);
-    document.getElementById("bg-canvas").classList.add(allBackgrounds[randomBackground]);
-
-    // {{ if l10n_enabled }}
-    if (navigator.language.substring(0, 2).toLowerCase() !== 'en') {
-        ((s, p) => { // localize the page (details here - https://github.com/tarampampam/error-pages/tree/master/l10n)
-            s.src = 'https://cdn.jsdelivr.net/gh/tarampampam/error-pages@2/l10n/l10n.min.js'; // '../l10n/l10n.js';
-            s.async = s.defer = true;
-            s.addEventListener('load', () => p.removeChild(s));
-            p.appendChild(s);
-        })(document.createElement('script'), document.body);
-    }
-    // {{ end }}
+  // {{ if l10n_enabled }}
+  if (navigator.language.substring(0, 2).toLowerCase() !== 'en') {
+    ((s, p) => { // localize the page (details here - https://github.com/tarampampam/error-pages/tree/master/l10n)
+      s.src = 'https://cdn.jsdelivr.net/gh/tarampampam/error-pages@2/l10n/l10n.min.js'; // '../l10n/l10n.js';
+      s.async = s.defer = true;
+      s.addEventListener('load', () => p.removeChild(s));
+      p.appendChild(s);
+    })(document.createElement('script'), document.body);
+  }
+  // {{ end }}
 </script>
 </body>
 <!--


### PR DESCRIPTION
## Description

Hello @tarampampam

Thanks for maintaining this cool framework for error pages. I found this project via a link in the depracted project https://github.com/guillaumebriday/traefik-custom-error-pages.

That project used illustrations created for [Laravel](https://github.com/LaravelCollective/errors). Since I wanted to keep using those pages, I migrated the templates from the old Jekyll format to the new Go template format used in this project.

There are four illustrations. I implemented a short random generator that selects one each time the page is refreshed.  Another idea would be to display the illustration that best reflects the user's real time. But for now, I've kept it simple.

Please let me know what you think about the new theme and if it fits in this project.

PS: I used https://yoksel.github.io/url-encoder/ to encode the SVGs for inline use in CSS.

BR, Lars

## Added
* Tempalte `orient`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests are required for my changes)_ <!-- feel free to drop this item from the list -->
- [x] I have made changes in the `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `Added` / `Changed` / `Fixed` sections
* Add a reference to the related issue or this PR `[#123](https://github.com/.../.../(issues|pull)/123)`

-->
