### PR TITLE
Add CatchAll functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
-## Unreleased
+## UNRELEASED
 
 ### Added
 
-- Added possibility catch all paths with error page 404 (using `--catch-all` flag for the `serve` or environment variable `CATCH_ALL=true`)
+- Added possibility catch all paths with error page 404 (using `--catch-all` flag for the `serve` or environment variable `CATCH_ALL=true`) [#217]
+
+[#217]:https://github.com/tarampampam/error-pages/issues/217
 
 ## v2.24.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Added possibility catch all paths with error page 404 (using `--catch-all` flag for the `serve` or environment variable `CATCH_ALL=true`)
+
 ## v2.24.0
 
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     <<: *app-service
     ports:
       - "8080:8080/tcp" # Open <http://127.0.0.1:8080>
-    command: sh -c "go build -buildvcs=false -o /tmp/app ./cmd/error-pages && /tmp/app serve --show-details --proxy-headers=X-Foo,Bar,Baz_blah"
+    command: sh -c "go build -buildvcs=false -o /tmp/app ./cmd/error-pages && /tmp/app serve --show-details --proxy-headers=X-Foo,Bar,Baz_blah --catch-all"
     healthcheck:
       test: ['CMD', '/tmp/app', '--log-json', 'healthcheck']
       interval: 4s

--- a/internal/cli/serve/command.go
+++ b/internal/cli/serve/command.go
@@ -32,6 +32,7 @@ const (
 	showDetailsFlagName      = "show-details"
 	proxyHTTPHeadersFlagName = "proxy-headers"
 	disableL10nFlagName      = "disable-l10n"
+	catchAllFlagName         = "catch-all"
 )
 
 const (
@@ -76,6 +77,7 @@ func NewCommand(log *zap.Logger) *cli.Command { //nolint:funlen
 				o.Default.PageCode = c.String(defaultErrorPageFlagName)
 				o.Default.HTTPCode = uint16(c.Uint(defaultHTTPCodeFlagName))
 				o.ShowDetails = c.Bool(showDetailsFlagName)
+				o.CatchAll = c.Bool(catchAllFlagName)
 
 				if headers := c.String(proxyHTTPHeadersFlagName); headers != "" { //nolint:nestif
 					var m = make(map[string]struct{})
@@ -150,6 +152,11 @@ func NewCommand(log *zap.Logger) *cli.Command { //nolint:funlen
 				Name:    disableL10nFlagName,
 				Usage:   "disable error pages localization",
 				EnvVars: []string{env.DisableL10n.String()},
+			},
+			&cli.BoolFlag{
+				Name:    catchAllFlagName,
+				Usage:   "catch all pages",
+				EnvVars: []string{env.CatchAll.String()},
 			},
 		},
 	}
@@ -240,6 +247,7 @@ func (cmd *command) Run( //nolint:funlen
 			zap.Strings("proxy headers", opt.ProxyHTTPHeaders),
 			zap.Bool("show request details", opt.ShowDetails),
 			zap.Bool("localization disabled", opt.L10n.Disabled),
+			zap.Bool("catch all enabled", opt.CatchAll),
 		)
 
 		if err := server.Start(ip, port); err != nil {

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -18,6 +18,7 @@ const (
 	ShowDetails      envVariable = "SHOW_DETAILS"       // show request details in response
 	ProxyHTTPHeaders envVariable = "PROXY_HTTP_HEADERS" // proxy HTTP request headers list (request -> response)
 	DisableL10n      envVariable = "DISABLE_L10N"       // disable pages localization
+	CatchAll         envVariable = "CATCH_ALL"          // catch all pages
 )
 
 // String returns environment variable name in the string representation.

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -17,6 +17,7 @@ func TestConstants(t *testing.T) {
 	assert.Equal(t, "SHOW_DETAILS", string(ShowDetails))
 	assert.Equal(t, "PROXY_HTTP_HEADERS", string(ProxyHTTPHeaders))
 	assert.Equal(t, "DISABLE_L10N", string(DisableL10n))
+	assert.Equal(t, "CATCH_ALL", string(CatchAll))
 }
 
 func TestEnvVariable_Lookup(t *testing.T) {
@@ -32,6 +33,7 @@ func TestEnvVariable_Lookup(t *testing.T) {
 		{giveEnv: ShowDetails},
 		{giveEnv: ProxyHTTPHeaders},
 		{giveEnv: DisableL10n},
+		{giveEnv: CatchAll},
 	}
 
 	for _, tt := range cases {

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -107,7 +107,13 @@ func (s *Server) Register(cfg *config.Config, templatePicker templatePicker, opt
 
 	s.router.GET("/metrics", metricsHandler.NewHandler(reg))
 
-	s.router.NotFound = notfoundHandler.NewHandler(cfg, templatePicker, s.rdr, opt)
+	// use index handler to catch all paths? Uses DEFAULT_ERROR_PAGE
+	if opt.CatchAll {
+		s.router.NotFound = indexHandler.NewHandler(cfg, templatePicker, s.rdr, opt)
+	} else {
+		// use default not found handler
+		s.router.NotFound = notfoundHandler.NewHandler(cfg, templatePicker, s.rdr, opt)
+	}
 
 	return nil
 }

--- a/internal/options/errorpage.go
+++ b/internal/options/errorpage.go
@@ -13,4 +13,5 @@ type ErrorPage struct {
 	}
 	ShowDetails      bool     // show request details in response
 	ProxyHTTPHeaders []string // proxy HTTP request headers list
+	CatchAll         bool     // catch all pages
 }


### PR DESCRIPTION
## Description

This pull request is based on the closed PR https://github.com/tarampampam/error-pages/pull/161

With the author's permission, I have incorporated the catch-all functionality into a new PR.

The catch-all functionality can be used especially when using error-pages in a Kubernetes project to - independent of the requested URL - always deliver an error page according to the `X-Code` HTTP header.

Since this PR has been closed before, please let me know what else is needed for this PR to be merged this time.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made changes in the `CHANGELOG.md` file
