### PR TITLE
fix: "Too big request header"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,6 @@ jobs: # Docs: <https://git.io/JvxXE>
       - uses: actions/checkout@v4
 
       - uses: gacts/setup-go-with-cache@v1
-        with: {go-version: 1.19}
 
       - uses: golangci/golangci-lint-action@v3
         with: {skip-pkg-cache: true, skip-build-cache: true}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs: # Docs: <https://git.io/JvxXE>
       - uses: actions/checkout@v4
 
       - uses: gacts/setup-go-with-cache@v1
+        with: {go-version-file: go.mod}
 
       - uses: golangci/golangci-lint-action@v3
         with: {skip-pkg-cache: true, skip-build-cache: true}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 ### Added
 
 - Error pages now translated into 🇵🇱 [#226]
+- Possibility to set custom read buffer size (using `--read-buffer-size` flag or environment variable `READ_BUFFER_SIZE`) [#238], [#244]
 
 [#226]:https://github.com/tarampampam/error-pages/pull/226
+[#238]:https://github.com/tarampampam/error-pages/issues/238
+[#244]:https://github.com/tarampampam/error-pages/pull/244
 
 ## v2.25.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,8 @@ ENV LISTEN_PORT="8080" \
     DEFAULT_ERROR_PAGE="404" \
     DEFAULT_HTTP_CODE="404" \
     SHOW_DETAILS="false" \
-    DISABLE_L10N="false"
+    DISABLE_L10N="false" \
+    READ_BUFFER_SIZE="2048"
 
 # Docs: <https://docs.docker.com/engine/reference/builder/#healthcheck>
 HEALTHCHECK --interval=7s --timeout=2s CMD ["/bin/error-pages", "--log-json", "healthcheck"]

--- a/internal/cli/serve/command.go
+++ b/internal/cli/serve/command.go
@@ -65,7 +65,7 @@ func NewCommand(log *zap.Logger) *cli.Command { //nolint:funlen
 			var (
 				ip   = c.String(shared.ListenAddrFlag.Name)
 				port = uint16(c.Uint(shared.ListenPortFlag.Name))
-				readBufferSize = uint16(c.Uint(shared.ReadBufferSizeFlag.Name))
+				readBufferSize = int(c.Int(shared.ReadBufferSizeFlag.Name))
 				o    options.ErrorPage
 			)
 
@@ -169,7 +169,7 @@ func NewCommand(log *zap.Logger) *cli.Command { //nolint:funlen
 
 // Run current command.
 func (cmd *command) Run( //nolint:funlen
-	parentCtx context.Context, log *zap.Logger, cfg *config.Config, ip string, port uint16, opt options.ErrorPage, readBufferSize uint16
+	parentCtx context.Context, log *zap.Logger, cfg *config.Config, ip string, port uint16, readBufferSize int, opt options.ErrorPage,
 ) error {
 	var (
 		ctx, cancel = context.WithCancel(parentCtx) // serve context creation
@@ -251,7 +251,7 @@ func (cmd *command) Run( //nolint:funlen
 			zap.Bool("show request details", opt.ShowDetails),
 			zap.Bool("localization disabled", opt.L10n.Disabled),
 			zap.Bool("catch all enabled", opt.CatchAll),
-			zap.Uint16("read buffer size", readBufferSize),
+			zap.Int("read buffer size", readBufferSize),
 		)
 
 		if err := server.Start(ip, port); err != nil {

--- a/internal/cli/shared/flags.go
+++ b/internal/cli/shared/flags.go
@@ -29,3 +29,11 @@ var ListenPortFlag = &cli.UintFlag{ //nolint:gochecknoglobals
 	Value:   8080, //nolint:gomnd
 	EnvVars: []string{env.ListenPort.String()},
 }
+
+var ReadBufferSizeFlag = &cli.UintFlag{ //nolint:gochecknoglobals
+	Name:    "read-buffer",
+	Aliases: []string{"b"},
+	Usage:   "Read Buffer Size",
+	Value:   2048, //nolint:gomnd
+	EnvVars: []string{env.ReadBufferSize.String()},
+}

--- a/internal/cli/shared/flags.go
+++ b/internal/cli/shared/flags.go
@@ -30,7 +30,7 @@ var ListenPortFlag = &cli.UintFlag{ //nolint:gochecknoglobals
 	EnvVars: []string{env.ListenPort.String()},
 }
 
-var ReadBufferSizeFlag = &cli.UintFlag{ //nolint:gochecknoglobals
+var ReadBufferSizeFlag = &cli.IntFlag{ //nolint:gochecknoglobals
 	Name:    "read-buffer",
 	Aliases: []string{"b"},
 	Usage:   "Read Buffer Size",

--- a/internal/cli/shared/flags.go
+++ b/internal/cli/shared/flags.go
@@ -29,11 +29,3 @@ var ListenPortFlag = &cli.UintFlag{ //nolint:gochecknoglobals
 	Value:   8080, //nolint:gomnd
 	EnvVars: []string{env.ListenPort.String()},
 }
-
-var ReadBufferSizeFlag = &cli.IntFlag{ //nolint:gochecknoglobals
-	Name:    "read-buffer",
-	Aliases: []string{"b"},
-	Usage:   "Read Buffer Size",
-	Value:   2048, //nolint:gomnd
-	EnvVars: []string{env.ReadBufferSize.String()},
-}

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -19,7 +19,7 @@ const (
 	ProxyHTTPHeaders envVariable = "PROXY_HTTP_HEADERS" // proxy HTTP request headers list (request -> response)
 	DisableL10n      envVariable = "DISABLE_L10N"       // disable pages localization
 	CatchAll         envVariable = "CATCH_ALL"          // catch all pages
-	ReadBufferSize   envVariable = "READ_BUFFER_SIZE"   // increase read buffer size in case you get 431 Request Header Fields Too Large errors
+	ReadBufferSize   envVariable = "READ_BUFFER_SIZE"   // https://github.com/tarampampam/error-pages/issues/238
 )
 
 // String returns environment variable name in the string representation.

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -19,6 +19,7 @@ const (
 	ProxyHTTPHeaders envVariable = "PROXY_HTTP_HEADERS" // proxy HTTP request headers list (request -> response)
 	DisableL10n      envVariable = "DISABLE_L10N"       // disable pages localization
 	CatchAll         envVariable = "CATCH_ALL"          // catch all pages
+	ReadBufferSize   envVariable = "READ_BUFFER_SIZE"   // increase read buffer size in case you get 431 Request Header Fields Too Large errors
 )
 
 // String returns environment variable name in the string representation.

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -18,6 +18,7 @@ func TestConstants(t *testing.T) {
 	assert.Equal(t, "PROXY_HTTP_HEADERS", string(ProxyHTTPHeaders))
 	assert.Equal(t, "DISABLE_L10N", string(DisableL10n))
 	assert.Equal(t, "CATCH_ALL", string(CatchAll))
+	assert.Equal(t, "READ_BUFFER_SIZE", string(ReadBufferSize))
 }
 
 func TestEnvVariable_Lookup(t *testing.T) {
@@ -34,6 +35,7 @@ func TestEnvVariable_Lookup(t *testing.T) {
 		{giveEnv: ProxyHTTPHeaders},
 		{giveEnv: DisableL10n},
 		{giveEnv: CatchAll},
+		{giveEnv: ReadBufferSize},
 	}
 
 	for _, tt := range cases {

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -39,13 +39,14 @@ const (
 	defaultIdleTimeout  = time.Second * 6
 )
 
-func NewServer(log *zap.Logger) Server {
+func NewServer(log *zap.Logger, readBufferSize uint16) Server {
 	rdr := tpl.NewTemplateRenderer()
 
 	return Server{
 		// fasthttp docs: <https://github.com/valyala/fasthttp>
 		fast: &fasthttp.Server{
 			WriteTimeout:          defaultWriteTimeout,
+			ReadBufferSize:        readBufferSize,
 			ReadTimeout:           defaultReadTimeout,
 			IdleTimeout:           defaultIdleTimeout,
 			NoDefaultServerHeader: true,

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -39,14 +39,14 @@ const (
 	defaultIdleTimeout  = time.Second * 6
 )
 
-func NewServer(log *zap.Logger, readBufferSize int) Server {
+func NewServer(log *zap.Logger, readBufferSize uint) Server {
 	rdr := tpl.NewTemplateRenderer()
 
 	return Server{
 		// fasthttp docs: <https://github.com/valyala/fasthttp>
 		fast: &fasthttp.Server{
 			WriteTimeout:          defaultWriteTimeout,
-			ReadBufferSize:        readBufferSize,
+			ReadBufferSize:        int(readBufferSize),
 			ReadTimeout:           defaultReadTimeout,
 			IdleTimeout:           defaultIdleTimeout,
 			NoDefaultServerHeader: true,

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -39,7 +39,7 @@ const (
 	defaultIdleTimeout  = time.Second * 6
 )
 
-func NewServer(log *zap.Logger, readBufferSize uint16) Server {
+func NewServer(log *zap.Logger, readBufferSize int) Server {
 	rdr := tpl.NewTemplateRenderer()
 
 	return Server{


### PR DESCRIPTION
## Description

New environment variable `READ_BUFFER_SIZE` to fix HTTP error 431 "Too big request header" if used in a setup where a lot of Cookies could be present. Solves issue #238.

Please feel free to modify. So far I only tested this as docker image and not when deployed via CLI or with nginx.