### PR TITLE
templates: use "word-break: keep-all"

### DIFF
--- a/templates/app-down.html
+++ b/templates/app-down.html
@@ -50,6 +50,7 @@
       width: 100%;
       overflow-x: hidden;
       font-size: 16px;
+      word-break: keep-all;
     }
 
     @media screen and (min-width: 2000px) {

--- a/templates/cats.html
+++ b/templates/cats.html
@@ -37,6 +37,7 @@
       color: var(--color-inverted);
       font-family: sans-serif;
       font-size: 16px;
+      word-break: keep-all;
     }
 
     @media screen and (min-width: 2000px) {

--- a/templates/connection.html
+++ b/templates/connection.html
@@ -50,6 +50,7 @@
       background-color: var(--color-bg-primary);
       font-family: sans-serif;
       font-size: 16px;
+      word-break: keep-all;
     }
 
     @media screen and (min-width: 2000px) {

--- a/templates/ghost.html
+++ b/templates/ghost.html
@@ -39,6 +39,7 @@
       color: var(--color-inverted);
       font-family: sans-serif;
       font-size: 16px;
+      word-break: keep-all;
     }
 
     @media screen and (min-width: 2000px) {

--- a/templates/hacker-terminal.html
+++ b/templates/hacker-terminal.html
@@ -25,6 +25,7 @@
       font-family: monospace;
       font-size: 16px;
       overflow: hidden;
+      word-break: keep-all;
     }
 
     body {

--- a/templates/l7.html
+++ b/templates/l7.html
@@ -37,6 +37,7 @@
       color: var(--color-inverted);
       font-family: sans-serif;
       font-size: 16px;
+      word-break: keep-all;
     }
 
     @media screen and (min-width: 2000px) {

--- a/templates/lost-in-space.html
+++ b/templates/lost-in-space.html
@@ -43,6 +43,7 @@
       color: var(--color-text-primary);
       font-family: sans-serif;
       font-size: 16px;
+      word-break: keep-all;
     }
 
     @media screen and (min-width: 2000px) {

--- a/templates/noise.html
+++ b/templates/noise.html
@@ -39,6 +39,7 @@
       overflow: hidden;
       font-family: sans-serif;
       font-size: 20px;
+      word-break: keep-all;
     }
 
     canvas {

--- a/templates/orient.html
+++ b/templates/orient.html
@@ -41,6 +41,7 @@
       padding: 0;
       background-color: var(--color-bg-primary);
       font-size: 16px;
+      word-break: keep-all;
     }
 
     @media screen and (min-width: 2000px) {

--- a/templates/shuffle.html
+++ b/templates/shuffle.html
@@ -37,6 +37,7 @@
       color: var(--color-inverted);
       font-family: monospace;
       font-size: 16px;
+      word-break: keep-all;
     }
 
     @media screen and (min-width: 2000px) {


### PR DESCRIPTION
## Description
In this PR, we address the handling of word breaking for CJK (Chinese, Japanese, Korean) languages within the project. Currently, the `word-break` property is set to `normal`, which functions adequately for English but may cause issues with CJK languages.

For CJK text, where words do not have clear boundaries such as spaces, setting `word-break: keep-all` ensures that text does not break arbitrarily. This change enhances readability and the layout of CJK text by preventing unintended line breaks within words.

## Changes Made
 * Updated the `word-break` property from `normal` to `keep-all` to better support CJK languages.
## Reason for Change (Related to #301)
In English, the difference between `word-break: normal` and `word-break: keep-all` is minimal because word boundaries are typically defined by spaces, allowing natural line breaks.

However, for CJK languages, characters do not have natural word boundaries. Using `word-break: keep-all` prevents unwanted line breaks within words, ensuring proper display and readability of CJK text.

This adjustment improves visual consistency and user experience for these languages.


```html
<div style="width: 300px;"> 
    <h1>normal</h1>
    <p style="word-break: normal;">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean necmollisnulla.Proin gravida velit dictum dui consequat malesuada.</p>
    
    <h1>break-all</h1>
    <p style="word-break: break-all;">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean necmollisnulla. Proin gravida velit dictum dui consequat malesuada.</p>
    
    <h1>keep-all</h1>
    <p style="word-break: keep-all;">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean necmollisnulla. Proin gravida velit dictum dui consequat malesuada.</p>
</div>
```