### PR TITLE
🌐 feat(win98): Add localization support to description

### DIFF
--- a/templates/win98.html
+++ b/templates/win98.html
@@ -341,7 +341,7 @@
           </svg>
         </div>
         <div class="content">
-          <p>{{ description }}<!-- {{- if show_details -}} -->.<!-- {{- end -}} --></p>
+          <p><span data-l10n>{{ description }}</span><!-- {{- if show_details -}} -->.<!-- {{- end -}} --></p>
           <!-- {{- if show_details -}} -->
           <div class="details">
             <!-- {{- if host -}} -->


### PR DESCRIPTION
Wrap the description text in `win98.html` with a `data-l10n` span to enable localization. This allows the description to be translated into different languages.
