### PR TITLE
feat: Added support for extra links and rewrote the `cats` template

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The following templates are built-in and available for use without any additiona
 [app-down-light]:https://github.com/user-attachments/assets/c5f42b53-51cd-47c4-a22f-553d44d2a288
 [app-down-dark]:https://github.com/user-attachments/assets/135bac8c-983f-461c-97ba-e653e9b9adfe
 [cats-link]:https://tarampampam.github.io/error-pages/cats/404.html
-[cats-light]:https://github.com/user-attachments/assets/dd084472-3c91-45c2-b1e7-183029cf5147
+[cats-light]:https://github.com/user-attachments/assets/7bea967e-a427-4ba2-a3a3-d71b9986ecfc
 [cats-dark]:https://github.com/user-attachments/assets/f9b945b2-3e19-44d5-842b-0c43c55d9b70
 [connection-link]:https://tarampampam.github.io/error-pages/connection/404.html
 [connection-light]:https://github.com/tarampampam/error-pages/assets/7326800/099ecc2d-e724-4d9c-b5ed-66ddabd71139

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ The following templates are built-in and available for use without any additiona
 [app-down-light]:https://github.com/user-attachments/assets/c5f42b53-51cd-47c4-a22f-553d44d2a288
 [app-down-dark]:https://github.com/user-attachments/assets/135bac8c-983f-461c-97ba-e653e9b9adfe
 [cats-link]:https://tarampampam.github.io/error-pages/cats/404.html
-[cats-light]:https://github.com/tarampampam/error-pages/assets/7326800/056cd00e-bc9a-4120-8325-310d7b0ebd1b
-[cats-dark]:https://github.com/tarampampam/error-pages/assets/7326800/5689880b-f770-406c-81dd-2d28629e6f2e
+[cats-light]:https://github.com/user-attachments/assets/dd084472-3c91-45c2-b1e7-183029cf5147
+[cats-dark]:https://github.com/user-attachments/assets/f9b945b2-3e19-44d5-842b-0c43c55d9b70
 [connection-link]:https://tarampampam.github.io/error-pages/connection/404.html
 [connection-light]:https://github.com/tarampampam/error-pages/assets/7326800/099ecc2d-e724-4d9c-b5ed-66ddabd71139
 [connection-dark]:https://github.com/tarampampam/error-pages/assets/7326800/3f03dc1b-c1ee-4a91-b3d7-e3b93c79020e

--- a/cmd/builder/app/app.go
+++ b/cmd/builder/app/app.go
@@ -38,6 +38,7 @@ type App struct {
 		customTemplate      string
 		l10nDisabled        bool
 		homepageURL         string
+		links               []tpl.Link
 	}
 }
 
@@ -60,6 +61,7 @@ func NewApp(name string) *App {
 		templateFlag            = newTemplateFlag()
 		disableL10nFlag         = shared.NewDisableL10nFlag()
 		homepageURLFlag         = shared.NewHomepageURLFlag(app.opt.homepageURL)
+		addLinksFlag            = shared.NewAddLinksFlag()
 	)
 
 	app.cmd.Flags = []cli.Flagger{
@@ -70,6 +72,7 @@ func NewApp(name string) *App {
 		&templateFlag,
 		&disableL10nFlag,
 		&homepageURLFlag,
+		&addLinksFlag,
 	}
 
 	app.cmd.Action = func(ctx context.Context, _ *cli.Command, _ []string) error {
@@ -88,6 +91,12 @@ func NewApp(name string) *App {
 
 		setIfFlagIsSet(&app.opt.customTemplate, templateFlag)
 		setIfFlagIsSet(&app.opt.homepageURL, homepageURLFlag)
+
+		if addLinksFlag.Value != nil && addLinksFlag.IsSet() {
+			if parsed, err := shared.ParseLinks(*addLinksFlag.Value); err == nil {
+				app.opt.links = parsed
+			}
+		}
 
 		// load custom template content if a source is provided (either URL, file path, or raw template string)
 		if src := app.opt.customTemplate; src != "" {
@@ -194,6 +203,7 @@ func (a *App) renderCustomTemplate(httpCodes codes.Codes, history map[string][]h
 			Message:     desc.Short,
 			Description: desc.Full,
 			HomepageURL: a.opt.homepageURL,
+			Links:       a.opt.links,
 			Config:      tpl.Config{L10nDisabled: a.opt.l10nDisabled},
 		})
 		if renderErr != nil {
@@ -254,6 +264,7 @@ func (a *App) renderBuiltInTemplates(httpCodes codes.Codes, history map[string][
 				Message:     desc.Short,
 				Description: desc.Full,
 				HomepageURL: a.opt.homepageURL,
+				Links:       a.opt.links,
 				Config:      tpl.Config{L10nDisabled: a.opt.l10nDisabled},
 			})
 			if renderErr != nil {

--- a/cmd/error-pages/app/app.go
+++ b/cmd/error-pages/app/app.go
@@ -45,6 +45,7 @@ type App struct {
 			templateName        string
 			rotationMode        tpl.RotationMode
 			homepageURL         string
+			links               []tpl.Link
 			customTemplates     struct {
 				html, json, xml, text string
 			}
@@ -88,6 +89,7 @@ func NewApp(name string) *App { //nolint:funlen
 		templateNameFlag        = newTemplateNameFlag(allTemplateNames, app.opt.errorPages.templateName)
 		rotationModeFlag        = newRotationModeFlag(app.opt.errorPages.rotationMode)
 		homepageURLFlag         = shared.NewHomepageURLFlag(app.opt.errorPages.homepageURL)
+		addLinksFlag            = shared.NewAddLinksFlag()
 		htmlTemplateFlag        = newHTMLTemplateFlag()
 		jsonTemplateFlag        = newJSONTemplateFlag()
 		xmlTemplateFlag         = newXMLTemplateFlag()
@@ -109,6 +111,7 @@ func NewApp(name string) *App { //nolint:funlen
 		&templateNameFlag,
 		&rotationModeFlag,
 		&homepageURLFlag,
+		&addLinksFlag,
 		&htmlTemplateFlag,
 		&jsonTemplateFlag,
 		&xmlTemplateFlag,
@@ -155,6 +158,13 @@ func NewApp(name string) *App { //nolint:funlen
 		}
 
 		setIfFlagIsSet(&app.opt.errorPages.homepageURL, homepageURLFlag)
+
+		if addLinksFlag.Value != nil && addLinksFlag.IsSet() {
+			if parsed, err := shared.ParseLinks(*addLinksFlag.Value); err == nil {
+				app.opt.errorPages.links = parsed
+			}
+		}
+
 		setIfFlagIsSet(&app.opt.errorPages.customTemplates.html, htmlTemplateFlag)
 		setIfFlagIsSet(&app.opt.errorPages.customTemplates.json, jsonTemplateFlag)
 		setIfFlagIsSet(&app.opt.errorPages.customTemplates.xml, xmlTemplateFlag)
@@ -303,6 +313,7 @@ func (a *App) run(ctx context.Context, log *logger.Logger) error {
 			a.opt.errorPages.showDetails,
 			a.opt.errorPages.l10nDisabled,
 			a.opt.errorPages.homepageURL,
+			a.opt.errorPages.links,
 		),
 		httpserver.WithErrorLog(logger.NewStdLog(log, logger.ErrorLevel)),
 	)
@@ -320,6 +331,7 @@ func (a *App) run(ctx context.Context, log *logger.Logger) error {
 		logger.Bool("show_details", a.opt.errorPages.showDetails),
 		logger.Strings("proxy_headers", a.opt.errorPages.proxyHeaders...),
 		logger.String("homepage_url", a.opt.errorPages.homepageURL),
+		logger.Int("links_count", len(a.opt.errorPages.links)),
 		logger.Bool("l10n_disabled", a.opt.errorPages.l10nDisabled),
 	)
 

--- a/deploy/helm/README.tpl.md
+++ b/deploy/helm/README.tpl.md
@@ -107,9 +107,44 @@ Override descriptions or add non-standard codes (e.g. `499`, `4**` wildcard):
 
 ```yaml
 config:
-  addCode: |
-    499=Client Closed Request|The client closed the connection before the server finished responding.
-    4**=Client Error|Something went wrong on the client side.
+  addCode:
+    - {code: "4**", message: "Client Error", description: "Something went wrong on the client side"}
+    - code: "499"
+      message: "Client Closed Request"
+      description: "The client closed the connection before the server finished responding"
+```
+
+Via `--set` (`--set-string` is required for numeric-looking codes like `499`):
+
+```shell
+helm install error-pages oci://ghcr.io/tarampampam/error-pages/charts/error-pages \
+  --set-string 'config.addCode[0].code=4**' \
+  --set 'config.addCode[0].message=Client Error' \
+  --set-string 'config.addCode[1].code=499' \
+  --set 'config.addCode[1].message=Client Closed Request' \
+  --set 'config.addCode[1].description=The client closed the connection before the server finished responding'
+```
+
+### Adding extra links
+
+Display additional links (status page, contact, privacy policy, etc.) on all error pages:
+
+```yaml
+config:
+  addLink:
+    - {label: "Status Page", url: "https://status.example.com"}
+    - {label: "Contact Support", url: "https://example.com/contact"}
+    - {label: "Privacy Policy", url: "https://example.com/privacy"}
+```
+
+Via `--set`:
+
+```shell
+helm install error-pages oci://ghcr.io/tarampampam/error-pages/charts/error-pages \
+  --set 'config.addLink[0].label=Status Page' \
+  --set 'config.addLink[0].url=https://status.example.com' \
+  --set 'config.addLink[1].label=Contact Support' \
+  --set 'config.addLink[1].url=https://example.com/contact'
 ```
 
 ## 💊 Support

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -75,7 +75,15 @@ spec:
             - {name: DISABLE_BUILT_IN_CODES, value: "true"}
             {{- end }}
             {{- if .addCode }}
-            - {name: ADD_CODE, value: {{ .addCode | toJson }}}
+              {{- $parts := list -}}
+              {{- range .addCode -}}
+                {{- $e := printf "%s=%s" .code .message -}}
+                {{- if .description -}}{{- $e = printf "%s|%s" $e .description -}}{{- end -}}
+                {{- $parts = append $parts $e -}}
+              {{- end }}
+            - name: ADD_CODE
+              value: |
+{{ join "\n" $parts | indent 16 }}
             {{- end }}
             {{- if .htmlTemplate.name }}
             - {name: TEMPLATE_NAME, value: "{{ .htmlTemplate.name }}"}
@@ -101,6 +109,15 @@ spec:
             {{- end }}
             {{- if .homepageUrl }}
             - {name: HOMEPAGE_URL, value: "{{ .homepageUrl }}"}
+            {{- end }}
+            {{- if .addLink }}
+              {{- $parts := list -}}
+              {{- range .addLink -}}
+                {{- $parts = append $parts (printf "%s=%s" .label .url) -}}
+              {{- end }}
+            - name: ADD_LINK
+              value: |
+{{ join "\n" $parts | indent 16 }}
             {{- end }}
             {{- if .disableL10n }}
             - {name: DISABLE_L10N, value: "true"}

--- a/deploy/helm/values.schema.json
+++ b/deploy/helm/values.schema.json
@@ -277,7 +277,19 @@
         },
         "addCode": {
           "oneOf": [
-            {"type": "string", "minLength": 1, "examples": ["599=Custom Error|Something went wrong"]},
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "code": {"type": "string", "minLength": 1},
+                  "message": {"type": "string", "minLength": 1},
+                  "description": {"type": "string", "minLength": 1}
+                },
+                "required": ["code", "message"],
+                "additionalProperties": false
+              }
+            },
             {"type": "null"}
           ]
         },
@@ -352,6 +364,23 @@
         "homepageUrl": {
           "oneOf": [
             {"type": "string", "minLength": 1},
+            {"type": "null"}
+          ]
+        },
+        "addLink": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "label": {"type": "string", "minLength": 1},
+                  "url": {"type": "string", "minLength": 1}
+                },
+                "required": ["label", "url"],
+                "additionalProperties": false
+              }
+            },
             {"type": "null"}
           ]
         },

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -127,10 +127,12 @@ config:
   proxyHeaders: null
   # -- (bool/null) Disable built-in HTTP status code descriptions
   disableBuiltInCodes: null
-  # -- (string/null) Add or override HTTP status codes. Format: `CODE=MESSAGE[\|DESCRIPTION]` (`CODE` supports wildcards like `4**`).
-  # Separate multiple entries with newlines
+  # -- ([]object/null) Add or override HTTP status codes. Each entry must have `code` and `message` (required), and
+  # optionally `description`. `code` supports wildcards like `4**`.
   # @default -- *all built-in codes*
-  addCode: null
+  addCode: null # Array<{code: string, message: string, description?: string}>
+  # -- ([]object/null) Extra links to display on error pages. Each entry must have `label` and `url` (both required).
+  addLink: null # Array<{label: string, url: string}>
 
   htmlTemplate:
     # -- (string/null) Built-in HTML template name (**ignored when `custom` is set**).

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -27,6 +27,7 @@ Options:
    --template-name="…"       Name of the built-in HTML template to use (app-down/cats/connection/ghost/hacker-terminal/l7/lost-in-space/noise/orient/shuffle/win98; ignored if a custom HTML template is set) (default: app-down) [$TEMPLATE_NAME, $HTML_TEMPLATE_NAME]
    --rotation-mode="…"       Mode for rotating built-in HTML templates (disabled/random-on-startup/random-on-each-request/random-hourly/random-daily; ignored if a custom HTML template is set) (default: disabled) [$ROTATION_MODE]
    --homepage-url="…"        Homepage URL to show as a link in error pages (e.g. https://app.example.com/home) (default: /) [$HOMEPAGE_URL]
+   --add-link="…"            Add extra links to error pages (format: 'LABEL=URL[||LABEL=URL...]'; separate multiple entries with '||', a newline, or a tab) [$ADD_LINK]
    --html-template="…"       Custom HTML template for error page responses (template text/URL/file path) [$HTML_TEMPLATE, $TEMPLATE]
    --json-template="…"       Custom JSON template for error page responses (template text/URL/file path) [$JSON_TEMPLATE]
    --xml-template="…"        Custom XML template for error page responses (template text/URL/file path) [$XML_TEMPLATE]
@@ -109,6 +110,17 @@ ADD_CODE="418=I'm a teapot|Short and stout
 499=Client Closed Request|The client closed the connection"
 ```
 
+### Adding extra links
+
+Add custom, labeled links (e.g. status page, contact, policy) to be displayed on every error page. Format: `LABEL=URL`.
+
+```bash
+# multiple links separated by || or newlines
+error-pages --add-link "Status Page=https://status.example.com||Contact=https://example.com/contact"
+```
+
+URLs may contain `=` signs - only the first `=` in each entry is used as the separator.
+
 ## Templates builder
 
 <!--GENERATED:BUILDER_CLI-->
@@ -130,6 +142,7 @@ Options:
    --template="…"                       Custom template for error pages [$TEMPLATE]
    --disable-l10n                       Disable localization of error pages (if the template supports localization) [$DISABLE_L10N]
    --homepage-url="…"                   Homepage URL to show as a link in error pages (e.g. https://app.example.com/home) [$HOMEPAGE_URL]
+   --add-link="…"                       Add extra links to error pages (format: 'LABEL=URL[||LABEL=URL...]'; separate multiple entries with '||', a newline, or a tab) [$ADD_LINK]
    --help, -h                           Show help
    --version, -v                        Print the version
 ```
@@ -180,4 +193,12 @@ builder --out ./error-pages --index
 ├── 403.html
 ├── 404.html
 └── ...
+```
+
+### Adding extra links
+
+The `--add-link` flag works the same way as in the HTTP server - see [Adding extra links](#adding-extra-links) above.
+
+```bash
+builder --add-link "Status Page=https://status.example.com||Contact=https://example.com/contact" --out ./error-pages
 ```

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -48,11 +48,29 @@ All templates receive a data object with the following fields:
 | `.RequestID`                 | `string` | Unique request ID *                                                    |
 | `.ForwardedFor`              | `string` | Original client IP(s) from `X-Forwarded-For` *                         |
 | `.Host`                      | `string` | Request `Host` header *                                                |
-| `.HomepageURL`               | `string` | Homepage URL set via `--homepage-url` (empty if not configured)        |
-| `.Config.ShowRequestDetails` | `bool`   | Whether `--show-details` is enabled                                    |
-| `.Config.L10nDisabled`       | `bool`   | Whether `--disable-l10n` is set                                        |
+| `.HomepageURL`               | `string`    | Homepage URL set via `--homepage-url` (empty if not configured)        |
+| `.Links`                     | `[]Link`    | Extra links set via `--add-link` (empty slice if not configured)       |
+| `.Config.ShowRequestDetails` | `bool`      | Whether `--show-details` is enabled                                    |
+| `.Config.L10nDisabled`       | `bool`      | Whether `--disable-l10n` is set                                        |
 
 > `*` - Requires `--show-details`
+
+Each element of `.Links` has the following sub-fields:
+
+| Sub-field     | Type     | Description           |
+|---------------|----------|-----------------------|
+| `.Label`      | `string` | Link text             |
+| `.URL`        | `string` | Target URL            |
+
+Example usage in a custom template:
+
+```html
+{{ if .Links }}
+<nav>
+  {{ range .Links }}<a href="{{ .URL }}">{{ .Label }}</a>{{ end }}
+</nav>
+{{ end }}
+```
 
 In addition to the fields above, templates also have access to a set of built-in functions (see below), which are
 pipeline-friendly (needle before haystack): `{{ .Message | default "Unknown" | upper }}`.

--- a/internal/cli/shared/flags.go
+++ b/internal/cli/shared/flags.go
@@ -6,6 +6,7 @@ import (
 
 	"gh.tarampamp.am/error-pages/v4/internal/cli"
 	"gh.tarampamp.am/error-pages/v4/internal/codes"
+	tpl "gh.tarampamp.am/error-pages/v4/internal/template"
 )
 
 // NewDisableBuiltInCodesFlag returns a flag that disables the built-in HTTP status code descriptions.
@@ -98,6 +99,58 @@ func NewHomepageURLFlag(def string) cli.Flag[string] {
 		EnvVars: []string{"HOMEPAGE_URL"},
 		Default: def,
 	}
+}
+
+// NewAddLinksFlag returns a flag for adding extra labeled links to error pages.
+func NewAddLinksFlag() cli.Flag[string] {
+	return cli.Flag[string]{
+		Names: []string{"add-link"},
+		Usage: "Add extra links to error pages " +
+			"(format: 'LABEL=URL[||LABEL=URL...]'; separate multiple entries with '||', a newline, or a tab)",
+		EnvVars: []string{"ADD_LINK"},
+		Validator: func(_ *cli.Command, s string) error {
+			_, err := ParseLinks(s)
+
+			return err
+		},
+	}
+}
+
+// ParseLinks parses the --add-link flag value into a slice of Link pairs.
+// Entries are separated by '||', newline, or tab; each entry has the format 'LABEL=URL' where only
+// the first '=' is used as the split point so that URLs containing '=' are handled correctly.
+// Returns an error if any entry is malformed.
+func ParseLinks(s string) ([]tpl.Link, error) {
+	s = strings.ReplaceAll(s, "\n", "||")
+	s = strings.ReplaceAll(s, "\t", "||")
+
+	parts := strings.Split(s, "||")
+	result := make([]tpl.Link, 0, len(parts))
+
+	for _, entry := range parts {
+		if entry = strings.TrimSpace(entry); entry == "" {
+			continue
+		}
+
+		label, url, ok := strings.Cut(entry, "=")
+		if !ok {
+			return nil, fmt.Errorf("wrong link entry %q: missing '='", entry)
+		}
+
+		label = strings.TrimSpace(label)
+		if label == "" {
+			return nil, fmt.Errorf("missing label in link entry %q", entry)
+		}
+
+		url = strings.TrimSpace(url)
+		if url == "" {
+			return nil, fmt.Errorf("missing URL in link entry %q", entry)
+		}
+
+		result = append(result, tpl.Link{Label: label, URL: url})
+	}
+
+	return result, nil
 }
 
 // NewDisableL10nFlag returns a flag that disables client-side localization for templates that support it.

--- a/internal/cli/shared/flags_test.go
+++ b/internal/cli/shared/flags_test.go
@@ -5,6 +5,7 @@ import (
 
 	"gh.tarampamp.am/error-pages/v4/internal/cli/shared"
 	"gh.tarampamp.am/error-pages/v4/internal/codes"
+	tpl "gh.tarampamp.am/error-pages/v4/internal/template"
 	"gh.tarampamp.am/error-pages/v4/internal/testutil/assert"
 )
 
@@ -180,6 +181,109 @@ func TestParseAddHTTPCodes(t *testing.T) {
 			t.Parallel()
 
 			got, err := shared.ParseAddHTTPCodes(tt.give)
+
+			if tt.checkErr != nil {
+				tt.checkErr(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.DeepEqual(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestNewAddLinksFlag(t *testing.T) {
+	t.Parallel()
+
+	f := shared.NewAddLinksFlag()
+
+	assert.Equal(t, 1, len(f.Names))
+	assert.Equal(t, "add-link", f.Names[0])
+	assert.Equal(t, 1, len(f.EnvVars))
+	assert.Equal(t, "ADD_LINK", f.EnvVars[0])
+	assert.True(t, f.Validator != nil)
+
+	assert.NoError(t, f.Validator(nil, "Status Page=https://status.example.com"))
+	assert.Error(t, f.Validator(nil, "bad-entry"))
+}
+
+func TestParseLinks(t *testing.T) {
+	t.Parallel()
+
+	for name, tt := range map[string]struct {
+		give     string
+		want     []tpl.Link
+		checkErr func(*testing.T, error)
+	}{
+		"empty string": {
+			give: "",
+			want: []tpl.Link{},
+		},
+		"single entry": {
+			give: "Status Page=https://status.example.com",
+			want: []tpl.Link{{Label: "Status Page", URL: "https://status.example.com"}},
+		},
+		"url with equals sign": {
+			give: "Search=https://example.com/search?q=foo&page=1",
+			want: []tpl.Link{{Label: "Search", URL: "https://example.com/search?q=foo&page=1"}},
+		},
+		"multiple entries/double pipe separator": {
+			give: "Status=https://status.example.com||Contact=https://example.com/contact",
+			want: []tpl.Link{
+				{Label: "Status", URL: "https://status.example.com"},
+				{Label: "Contact", URL: "https://example.com/contact"},
+			},
+		},
+		"multiple entries/newline separator": {
+			give: "Status=https://status.example.com\nContact=https://example.com/contact",
+			want: []tpl.Link{
+				{Label: "Status", URL: "https://status.example.com"},
+				{Label: "Contact", URL: "https://example.com/contact"},
+			},
+		},
+		"multiple entries/tab separator": {
+			give: "Status=https://status.example.com\tContact=https://example.com/contact",
+			want: []tpl.Link{
+				{Label: "Status", URL: "https://status.example.com"},
+				{Label: "Contact", URL: "https://example.com/contact"},
+			},
+		},
+		"empty entries in the middle are skipped": {
+			give: "Status=https://status.example.com||||Contact=https://example.com/contact",
+			want: []tpl.Link{
+				{Label: "Status", URL: "https://status.example.com"},
+				{Label: "Contact", URL: "https://example.com/contact"},
+			},
+		},
+		"whitespace trimmed around label and url": {
+			give: "  Status Page  =  https://status.example.com  ",
+			want: []tpl.Link{{Label: "Status Page", URL: "https://status.example.com"}},
+		},
+		"missing equals sign": {
+			give:     "Status Page",
+			checkErr: func(t *testing.T, err error) { assert.ErrorContains(t, err, "missing '='") },
+		},
+		"empty label": {
+			give:     "=https://status.example.com",
+			checkErr: func(t *testing.T, err error) { assert.ErrorContains(t, err, "missing label") },
+		},
+		"whitespace-only label": {
+			give:     "   =https://status.example.com",
+			checkErr: func(t *testing.T, err error) { assert.ErrorContains(t, err, "missing label") },
+		},
+		"empty url": {
+			give:     "Status=",
+			checkErr: func(t *testing.T, err error) { assert.ErrorContains(t, err, "missing URL") },
+		},
+		"whitespace-only url": {
+			give:     "Status=   ",
+			checkErr: func(t *testing.T, err error) { assert.ErrorContains(t, err, "missing URL") },
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := shared.ParseLinks(tt.give)
 
 			if tt.checkErr != nil {
 				tt.checkErr(t, err)

--- a/internal/httpserver/handler.go
+++ b/internal/httpserver/handler.go
@@ -10,6 +10,7 @@ import (
 	"gh.tarampamp.am/error-pages/v4/internal/httpserver/handlers/version"
 	"gh.tarampamp.am/error-pages/v4/internal/httpserver/middleware"
 	"gh.tarampamp.am/error-pages/v4/internal/logger"
+	tpl "gh.tarampamp.am/error-pages/v4/internal/template"
 )
 
 // NewHandler creates a new HTTP handler that serves all server endpoints. It does not use MUX because the
@@ -24,6 +25,7 @@ func NewHandler(
 	showDetails bool,
 	l10nDisabled bool,
 	homepageURL string,
+	links []tpl.Link,
 ) http.Handler {
 	const (
 		healthzEndpoint    = "/healthz"
@@ -48,6 +50,7 @@ func NewHandler(
 		showDetails,
 		l10nDisabled,
 		homepageURL,
+		links,
 	)
 
 	return middleware.Apply(

--- a/internal/httpserver/handlers/error_page/handler.go
+++ b/internal/httpserver/handlers/error_page/handler.go
@@ -36,6 +36,7 @@ func New( //nolint:funlen
 	showDetails bool,
 	l10nDisabled bool,
 	homepageURL string,
+	links []tpl.Link,
 ) http.Handler {
 	// bufPool reuses the render buffer across requests to avoid per-request heap allocation for the response body
 	bufPool := sync.Pool{New: func() any { return new(bytes.Buffer) }}
@@ -95,6 +96,7 @@ func New( //nolint:funlen
 			Message:     codeDesc.Short,
 			Description: codeDesc.Full,
 			HomepageURL: homepageURL,
+			Links:       links,
 			Config: tpl.Config{
 				ShowRequestDetails: showDetails,
 				L10nDisabled:       l10nDisabled,

--- a/internal/httpserver/handlers/error_page/handler_test.go
+++ b/internal/httpserver/handlers/error_page/handler_test.go
@@ -47,6 +47,7 @@ func TestNew(t *testing.T) {
 			false,
 			false,
 			"",
+			nil,
 		)
 
 		for name, tc := range map[string]struct {
@@ -94,6 +95,7 @@ func TestNew(t *testing.T) {
 				false,
 				false,
 				"",
+				nil,
 			)
 		}
 
@@ -181,6 +183,7 @@ func TestNew(t *testing.T) {
 			false,
 			false,
 			"",
+			nil,
 		)
 
 		for name, tc := range map[string]struct {
@@ -381,6 +384,7 @@ func TestNew(t *testing.T) {
 					false,
 					false,
 					"",
+					nil,
 				)
 
 				req := httptest.NewRequest(http.MethodGet, tc.givePath, nil)
@@ -407,6 +411,7 @@ func TestNew(t *testing.T) {
 			false,
 			false,
 			"",
+			nil,
 		)
 
 		for name, tc := range map[string]struct {
@@ -485,6 +490,7 @@ func TestNew(t *testing.T) {
 					false,
 					false,
 					"",
+					nil,
 				)
 
 				req := httptest.NewRequest(http.MethodGet, "/404", nil)
@@ -549,6 +555,7 @@ func TestNew(t *testing.T) {
 					false,
 					false,
 					"",
+					nil,
 				)
 
 				req := httptest.NewRequest(http.MethodGet, tc.givePath, nil)
@@ -575,6 +582,7 @@ func TestNew(t *testing.T) {
 			false,
 			false,
 			"",
+			nil,
 		)
 
 		for name, tc := range map[string]struct {
@@ -614,6 +622,7 @@ func TestNew(t *testing.T) {
 			false,
 			false,
 			"",
+			nil,
 		)
 
 		for name, tc := range map[string]struct {
@@ -654,6 +663,7 @@ func TestNew(t *testing.T) {
 			false,
 			false,
 			"",
+			nil,
 		)
 
 		for name, tc := range map[string]struct {
@@ -700,6 +710,7 @@ func TestNew(t *testing.T) {
 				true,
 				false,
 				"",
+				nil,
 			)
 
 			req := httptest.NewRequest(http.MethodGet, "/500", nil)
@@ -735,6 +746,7 @@ func TestNew(t *testing.T) {
 				false,
 				false,
 				"",
+				nil,
 			)
 
 			req := httptest.NewRequest(http.MethodGet, "/500", nil)
@@ -765,6 +777,7 @@ func TestNew(t *testing.T) {
 			false,
 			false,
 			"",
+			nil,
 		)
 
 		wantLen := strconv.Itoa(len(tplBody))
@@ -818,6 +831,7 @@ func TestNew(t *testing.T) {
 			false,
 			false,
 			"",
+			nil,
 		)
 
 		for name, tc := range map[string]struct {
@@ -902,6 +916,7 @@ func TestNew(t *testing.T) {
 				false,
 				false,
 				"",
+				nil,
 			)
 
 			req := httptest.NewRequest(http.MethodGet, "/404", nil)

--- a/internal/template/data.go
+++ b/internal/template/data.go
@@ -20,15 +20,23 @@ type Data struct {
 	ForwardedFor string // (ingress-nginx, Envoy Gateway) the value of the `X-Forwarded-For` header
 	Host         string // the value of the `Host` header
 	HomepageURL  string // homepage URL (optional, set via --homepage-url)
+	Links        []Link // additional links to display on the error page (optional, set via --add-link)
 	Config       Config // configuration values
 
 	// TODO: add incoming request headers as a map[string]string field, so they can be used in the templates?
 }
 
+// Link represents a labeled hyperlink that can be displayed in error page templates.
+//
+// DO NOT MODIFY EXISTING FIELDS OR THEIR TYPES.
+type Link struct {
+	Label string // link text shown to the user
+	URL   string // target URL
+}
+
 // Config holds configuration values that can be used in the templates.
 //
-// DO NOT MODIFY EXISTING FIELDS OR THEIR TYPES, as they are used in the templates and may be referenced in
-// the template files.
+// DO NOT MODIFY EXISTING FIELDS OR THEIR TYPES.
 type Config struct {
 	ShowRequestDetails bool // show request details?
 	L10nDisabled       bool // disable localization feature?

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -24,6 +24,10 @@ func TestTemplate_Render(t *testing.T) {
 		ForwardedFor: "123.123.123.123:321",
 		Host:         "test-host",
 		HomepageURL:  "https://app.example.com/home",
+		Links: []tpl.Link{
+			{Label: "Status Page", URL: "https://status.example.com"},
+			{Label: "Contact", URL: "https://example.com/contact"},
+		},
 		Config: tpl.Config{
 			ShowRequestDetails: true,
 			L10nDisabled:       true,
@@ -46,7 +50,9 @@ ForwardedFor={{ .ForwardedFor }}
 Host={{ .Host }}
 HomepageURL={{ .HomepageURL }}
 Config.ShowRequestDetails={{ .Config.ShowRequestDetails }}
-Config.L10nDisabled={{ .Config.L10nDisabled }}`
+Config.L10nDisabled={{ .Config.L10nDisabled }}
+{{ range .Links }}Link={{ .Label }}={{ .URL }}
+{{ end }}`
 
 		tmpl, err := tpl.New(src)
 		assert.NoError(t, err)
@@ -67,7 +73,10 @@ ForwardedFor=123.123.123.123:321
 Host=test-host
 HomepageURL=https://app.example.com/home
 Config.ShowRequestDetails=true
-Config.L10nDisabled=true`, string(got))
+Config.L10nDisabled=true
+Link=Status Page=https://status.example.com
+Link=Contact=https://example.com/contact
+`, string(got))
 	})
 
 	t.Run("render built-in templates", func(t *testing.T) {
@@ -95,6 +104,22 @@ Config.L10nDisabled=true`, string(got))
 
 					_, err = template.Render(tpl.Data{})
 					assert.NoError(t, err)
+				})
+
+				t.Run("links rendered", func(t *testing.T) {
+					t.Parallel()
+
+					template, err := tpl.New(content)
+					assert.NoError(t, err)
+
+					rendered, renderErr := template.Render(tpl.Data{
+						Links: []tpl.Link{
+							{Label: "My Status Page", URL: "https://status.example.com"},
+						},
+					})
+					assert.NoError(t, renderErr)
+					assert.Contains(t, string(rendered), "My Status Page")
+					assert.Contains(t, string(rendered), "https://status.example.com")
 				})
 			})
 		}

--- a/templates/html/app-down.tpl.html
+++ b/templates/html/app-down.tpl.html
@@ -174,6 +174,15 @@
           font-size: clamp(0.9rem, 2.3vmin, 1rem);
           color: var(--color-text-secondary);
 
+          /* {{ if .Links }} */
+          ul {
+            margin: 0;
+            padding: 0;
+            list-style: none;
+            font-size: clamp(0.9rem, 2.3vmin, 1rem);
+          }
+          /* {{ end }} */
+
           a {
             color: inherit;
             text-decoration: underline;
@@ -399,6 +408,16 @@
     </nav>
     <!-- {{ end }} -->
 
+    <!-- {{- if .Links -}} -->
+    <nav class="extra-links" aria-label="Additional links">
+      <ul>
+        <!-- {{- range .Links -}} -->
+        <li data-l10n><a href="{{ .URL }}" data-l10n>{{ .Label }}</a></li>
+        <!-- {{- end -}} -->
+      </ul>
+    </nav>
+    <!-- {{- end -}} -->
+
     <!-- {{- if .Config.ShowRequestDetails -}} -->
     <section class="details" aria-labelledby="details-heading">
       <h2 id="details-heading" data-l10n>Request details</h2>
@@ -436,6 +455,7 @@
   </section>
 
   <figure class="pic" aria-hidden="true">
+    <!-- region svg-pic -->
     <svg id="pic" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" focusable="false" role="presentation">
       <path d="M100.31 43.593l214.941-11.34 6.379 120.902-214.941 11.34z" class="Z"/>
       <path class="B" d="M321.63 153.16l-.13-2.17-.35-6.31-1.33-24.16-4.76-88.25.21.18-214.93
@@ -935,6 +955,7 @@
           100.39 0 0 1 .26 10.32 100.39 100.39 0 0 1-.26 10.32z"/>
       </defs>
     </svg>
+    <!-- endregion -->
   </figure>
 </main>
 

--- a/templates/html/cats.tpl.html
+++ b/templates/html/cats.tpl.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="robots" content="nofollow,noarchive,noindex">
-  <title>{{ .Message }}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title data-l10n>{{ .Message }}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <!-- {{ if or (eq .StatusCode 408) (eq .StatusCode 425) (eq .StatusCode 429) (eq .StatusCode 500) (eq .StatusCode 502) (eq .StatusCode 503) (eq .StatusCode 504) }} -->
   <meta http-equiv="refresh" content="30">
   <!-- {{ end }} -->
@@ -12,150 +12,228 @@
   <meta name="description" content="{{ .Description | escape }}">
   <meta property="og:title" content="{{ .StatusCode }}: {{ .Message | escape }}">
   <meta property="og:description" content="{{ .Description | escape }}">
+  <meta property="og:locale" content="en_US">
   <meta property="twitter:title" content="{{ .StatusCode }}: {{ .Message | escape }}">
   <meta property="twitter:description" content="{{ .Description | escape }}">
+  <meta name="format-detection" content="telephone=no">
   <style>
     :root {
-      --color-primary: #fff;
-      --color-inverted: #202020;
+      --color-bg: #e8e1d2;
+      --color-text: #2a2520;
+      --color-polaroid: #fcf9f1;
+      --color-shadow: rgba(50, 30, 20, 0.28);
     }
 
     @media (prefers-color-scheme: dark) {
       :root {
-        --color-primary: #000;
-        --color-inverted: #fff;
+        --color-bg: #1a1714;
+        --color-text: #d4ccba;
+        --color-polaroid: #ddd5c2;
+        --color-shadow: rgba(0, 0, 0, 0.55);
       }
+    }
+
+    @view-transition {
+      navigation: auto;
+    }
+
+    *, *::before, *::after {
+      box-sizing: border-box;
     }
 
     html, body {
       margin: 0;
       padding: 0;
-      min-height: 100%;
-      height: 100%;
-      width: 100%;
-      background-color: var(--color-primary);
-      color: var(--color-inverted);
-      font-family: sans-serif;
-      font-size: 16px;
-      word-break: keep-all;
-    }
-
-    @media screen and (min-width: 2000px) {
-      html, body {
-        font-size: 22px;
-      }
+      overflow: hidden;
+      overscroll-behavior: none;
     }
 
     body {
+      height: 100dvh;
       display: flex;
-      justify-content: center;
       align-items: center;
+      justify-content: center;
+      padding: clamp(1rem, 4vmin, 3rem);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      background-color: var(--color-bg);
+      color: var(--color-text);
+    }
+
+    @media (max-height: 600px), (max-width: 380px) {
+      html, body {
+        overflow: auto;
+        overscroll-behavior: auto;
+      }
+      body {
+        height: auto;
+        min-height: 100dvh;
+      }
+    }
+
+    main {
+      display: flex;
       flex-direction: column;
-      height: 100%;
-    }
+      align-items: center;
+      justify-content: center;
+      gap: clamp(1rem, 2vmin, 1.5rem);
+      max-width: min(100%, 64rem);
+      max-height: 100%;
 
-    article img {
-      width: 100%;
-      max-width: 750px;
-      box-shadow: 0 30px 0 -20px rgba(0, 0, 0, 0.2);
-    }
+      article {
+        position: relative;
+        padding: 1em 1em clamp(10px, 20%, 15%);
+        width: 90%;
+        max-width: 600px;
+        box-sizing: border-box;
+        transform: rotate(-2.5deg);
+        transition: transform 0.4s ease;
 
-    /* {{ if .Config.ShowRequestDetails }} */
-    table.details {
-      table-layout: fixed;
-      width: 100%;
-      opacity: .8;
-      padding-top: 1.5em;
-    }
+        &::before {
+          content: "";
+          position: absolute;
+          inset: 0;
+          background: var(--color-polaroid);
+          box-shadow: 0 12px 28px var(--color-shadow), 0 3px 6px var(--color-shadow);
+          z-index: -1;
+        }
 
-    table.details td {
-      white-space: nowrap;
-      font-size: 0.7em;
-    }
+        &::after {
+          content: "";
+          position: absolute;
+          inset: 0;
+          background: var(--color-polaroid);
+          box-shadow: 0 8px 18px var(--color-shadow);
+          transform: rotate(4deg) translate(7px, 8px);
+          z-index: -2;
+        }
 
-    table.details .name,
-    table.details .value {
-      width: 50%;
-    }
+        &:hover {
+          transform: rotate(0) scale(1.02);
+        }
 
-    table.details .name::first-letter,
-    table.details .value::first-letter {
-      font-weight: bold;
-    }
+        img {
+          display: block;
+          width: 100%;
+          height: auto;
+          aspect-ratio: 5 / 4;
+          box-shadow: none;
+          user-select: none;
+        }
+      }
 
-    table.details .name {
-      text-align: right;
-      padding-right: .4em;
-      width: 50%;
-    }
+      nav.links {
+        margin-top: 1em;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 1.5em;
+        width: 100%;
 
-    table.details .value {
-      text-align: left;
-      padding-left: .4em;
-      font-family: monospace;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
+        a {
+          color: var(--color-text);
+          opacity: .7;
+        }
+      }
 
-    /* {{ end }} */
+      /* {{ if .Config.ShowRequestDetails }} */
+      table.details {
+        table-layout: fixed;
+        max-width: 500px;
+        opacity: .55;
+
+        td {
+          font-size: 0.75em;
+        }
+
+        .name,
+        .value {
+          width: 50%;
+        }
+
+        .name {
+          text-align: right;
+          padding-right: .4em;
+        }
+
+        .value {
+          text-align: left;
+          padding-left: .4em;
+          font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+          word-break: break-all;
+          overflow-wrap: anywhere;
+        }
+      }
+      /* {{ end }} */
+    }
   </style>
 </head>
 <body>
-<article>
-  <img src="https://http.cat/{{ .StatusCode }}.jpg" alt="{{ .Message }}">
-</article>
+<main>
+  <article>
+    <img src="https://http.cat/{{ .StatusCode }}.jpg" alt="{{ .Message }}" decoding="async" width="750" height="600">
+  </article>
 
-<!-- {{- if .Config.ShowRequestDetails -}} -->
-<table class="details">
-  <tbody>
-  <!-- {{- if .Host -}} -->
-  <tr>
-    <td class="name" data-l10n>Host</td>
-    <td class="value">{{ .Host }}</td>
-  </tr>
-  <!-- {{- end }}{{ if .OriginalURI -}} -->
-  <tr>
-    <td class="name" data-l10n>Original URI</td>
-    <td class="value">{{ .OriginalURI }}</td>
-  </tr>
-  <!-- {{- end }}{{ if .ForwardedFor -}} -->
-  <tr>
-    <td class="name" data-l10n>Forwarded for</td>
-    <td class="value">{{ .ForwardedFor }}</td>
-  </tr>
-  <!-- {{- end }}{{ if .Namespace -}} -->
-  <tr>
-    <td class="name" data-l10n>Namespace</td>
-    <td class="value">{{ .Namespace }}</td>
-  </tr>
-  <!-- {{- end }}{{ if .IngressName -}} -->
-  <tr>
-    <td class="name" data-l10n>Ingress name</td>
-    <td class="value">{{ .IngressName }}</td>
-  </tr>
-  <!-- {{- end }}{{ if .ServiceName -}} -->
-  <tr>
-    <td class="name" data-l10n>Service name</td>
-    <td class="value">{{ .ServiceName }}</td>
-  </tr>
-  <!-- {{- end }}{{ if .ServicePort -}} -->
-  <tr>
-    <td class="name" data-l10n>Service port</td>
-    <td class="value">{{ .ServicePort }}</td>
-  </tr>
-  <!-- {{- end }}{{ if .RequestID -}} -->
-  <tr>
-    <td class="name" data-l10n>Request ID</td>
-    <td class="value">{{ .RequestID }}</td>
-  </tr>
+  <nav class="links" aria-label="Additional links">
+    <!-- {{ if .HomepageURL }} -->
+    <a href="{{ .HomepageURL }}" data-l10n>Go to homepage</a>
+    <!-- {{ end }} -->
+    <!-- {{- range .Links -}} -->
+    <a href="{{ .URL }}" data-l10n>{{ .Label }}</a>
+    <!-- {{- end -}} -->
+  </nav>
+
+  <!-- {{- if .Config.ShowRequestDetails -}} -->
+  <table class="details">
+    <tbody>
+    <!-- {{- if .Host -}} -->
+    <tr>
+      <td class="name" data-l10n>Host</td>
+      <td class="value">{{ .Host }}</td>
+    </tr>
+    <!-- {{- end }}{{ if .OriginalURI -}} -->
+    <tr>
+      <td class="name" data-l10n>Original URI</td>
+      <td class="value">{{ .OriginalURI }}</td>
+    </tr>
+    <!-- {{- end }}{{ if .ForwardedFor -}} -->
+    <tr>
+      <td class="name" data-l10n>Forwarded for</td>
+      <td class="value">{{ .ForwardedFor }}</td>
+    </tr>
+    <!-- {{- end }}{{ if .Namespace -}} -->
+    <tr>
+      <td class="name" data-l10n>Namespace</td>
+      <td class="value">{{ .Namespace }}</td>
+    </tr>
+    <!-- {{- end }}{{ if .IngressName -}} -->
+    <tr>
+      <td class="name" data-l10n>Ingress name</td>
+      <td class="value">{{ .IngressName }}</td>
+    </tr>
+    <!-- {{- end }}{{ if .ServiceName -}} -->
+    <tr>
+      <td class="name" data-l10n>Service name</td>
+      <td class="value">{{ .ServiceName }}</td>
+    </tr>
+    <!-- {{- end }}{{ if .ServicePort -}} -->
+    <tr>
+      <td class="name" data-l10n>Service port</td>
+      <td class="value">{{ .ServicePort }}</td>
+    </tr>
+    <!-- {{- end }}{{ if .RequestID -}} -->
+    <tr>
+      <td class="name" data-l10n>Request ID</td>
+      <td class="value">{{ .RequestID }}</td>
+    </tr>
+    <!-- {{- end -}} -->
+    <tr>
+      <td class="name" data-l10n>Timestamp</td>
+      <td class="value">{{ now.Unix }}</td>
+    </tr>
+    </tbody>
+  </table>
   <!-- {{- end -}} -->
-  <tr>
-    <td class="name" data-l10n>Timestamp</td>
-    <td class="value">{{ now.Unix }}</td>
-  </tr>
-  </tbody>
-</table>
-<!-- {{- end -}} -->
+</main>
 
 <!-- {{- if (not .Config.L10nDisabled) -}} -->
 <script>// {{ l10nScript }}</script>

--- a/templates/html/connection.tpl.html
+++ b/templates/html/connection.tpl.html
@@ -193,6 +193,23 @@
       color: var(--color-text-secondary);
     }
 
+    footer .links {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: center;
+      gap: 1em;
+      font-size: clamp(0.9rem, 2.3vmin, 1rem);
+      margin: clamp(2rem, 5vmin, 3.5rem) 0;
+    }
+
+    footer .links a {
+      color: var(--color-text-secondary);
+      text-decoration: underline;
+      font-size: .85em;
+    }
+
     /* {{ if .Config.ShowRequestDetails }} */
     footer .details {
       margin-top: 20px;
@@ -308,6 +325,16 @@
   </div>
 </div>
 <footer>
+  <nav class="links" aria-label="Additional links">
+    <!-- {{ if .HomepageURL }} -->
+    <a href="{{ .HomepageURL }}" data-l10n>Go to homepage</a>
+    <!-- {{ end }} -->
+
+    <!-- {{- range .Links -}} -->
+    <a href="{{ .URL }}" data-l10n>{{ .Label }}</a>
+    <!-- {{- end -}} -->
+  </nav>
+
   <!-- {{- if .Config.ShowRequestDetails -}} -->
   <div class="details">
     <ul>

--- a/templates/html/ghost.tpl.html
+++ b/templates/html/ghost.tpl.html
@@ -106,6 +106,25 @@
       opacity: .9;
     }
 
+    .links {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: center;
+      gap: 1em;
+      font-size: clamp(0.9rem, 2.3vmin, 1rem);
+      margin: 1em 0;
+    }
+
+    .links a {
+      color: var(--color-inverted);
+      text-decoration: underline;
+      font-weight: lighter;
+      font-size: .85em;
+      opacity: 0.75;
+    }
+
     /* {{ if .Config.ShowRequestDetails }} */
     table.details {
       table-layout: fixed;
@@ -189,6 +208,16 @@
 
   <h3><span data-l10n>Error</span> {{ .StatusCode }}</h3>
   <p class="description" data-l10n>{{ .Description }}</p>
+
+  <nav class="links" aria-label="Additional links">
+    <!-- {{ if .HomepageURL }} -->
+    <a href="{{ .HomepageURL }}" data-l10n>Go to homepage</a>
+    <!-- {{ end }} -->
+
+    <!-- {{- range .Links -}} -->
+    <a href="{{ .URL }}" data-l10n>{{ .Label }}</a>
+    <!-- {{- end -}} -->
+  </nav>
 
   <!-- {{- if .Config.ShowRequestDetails -}} -->
   <table class="details">

--- a/templates/html/hacker-terminal.tpl.html
+++ b/templates/html/hacker-terminal.tpl.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="robots" content="nofollow,noarchive,noindex">
-  <title>{{ .Message }}</title>
+  <title data-l10n>{{ .Message }}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- {{ if or (eq .StatusCode 408) (eq .StatusCode 425) (eq .StatusCode 429) (eq .StatusCode 500) (eq .StatusCode 502) (eq .StatusCode 503) (eq .StatusCode 504) }} -->
   <meta http-equiv="refresh" content="30">
@@ -141,11 +141,6 @@
     .details p::before {
       content: "$ ";
     }
-
-    .details code {
-      font-size: 0.9em;
-    }
-
     /* {{ end }} */
   </style>
 </head>
@@ -156,6 +151,19 @@
   <h1><span data-l10n>Error</span> <span class="error_code">{{ .StatusCode }}</span></h1>
   <p class="output" data-l10n>{{ .Description }}.</p>
   <p class="output"><span data-l10n>Good luck</span>.</p>
+
+  <!-- {{ if .HomepageURL }} -->
+  <p class="output"><a href="{{ .HomepageURL }}" data-l10n>Go to homepage</a></p>
+  <!-- {{ end }} -->
+
+  <!-- {{- if .Links -}} -->
+  <p class="output">
+  <!-- {{- range .Links -}} -->
+  <a href="{{ .URL }}" data-l10n>{{ .Label }}</a>
+  <!-- {{- end -}} -->
+  </p>
+  <!-- {{- end -}} -->
+
   <!-- {{- if .Config.ShowRequestDetails -}} -->
   <div class="details">
     <!-- {{- if .Host -}} -->

--- a/templates/html/l7.tpl.html
+++ b/templates/html/l7.tpl.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="robots" content="nofollow,noarchive,noindex">
-  <title>{{ .Message }}</title>
+  <title data-l10n>{{ .Message }}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- {{ if or (eq .StatusCode 408) (eq .StatusCode 425) (eq .StatusCode 429) (eq .StatusCode 500) (eq .StatusCode 502) (eq .StatusCode 503) (eq .StatusCode 504) }} -->
   <meta http-equiv="refresh" content="30">
@@ -61,6 +61,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      flex-direction: row;
     }
 
     article .code h1, article .desc p {
@@ -106,6 +107,21 @@
       font-family: monospace;
     }
     /* {{ end }} */
+
+    main nav {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      flex-direction: row;
+      margin-top: 1.5em;
+      gap: .7em;
+    }
+
+    main nav a {
+      color: var(--color-inverted);
+      opacity: .75;
+      font-size: 0.9em;
+    }
   </style>
 </head>
 <body>
@@ -163,6 +179,15 @@
       <!-- {{- end -}} -->
     </div>
   </article>
+
+  <nav aria-label="Additional links">
+    <!-- {{ if .HomepageURL }} -->
+    <a href="{{ .HomepageURL }}" data-l10n>Go to homepage</a>
+    <!-- {{ end }} -->
+    <!-- {{- range .Links -}} -->
+    <a href="{{ .URL }}" data-l10n>{{ .Label }}</a>
+    <!-- {{- end -}} -->
+  </nav>
 </main>
 
 <!-- {{- if (not .Config.L10nDisabled) -}} -->

--- a/templates/html/lost-in-space.tpl.html
+++ b/templates/html/lost-in-space.tpl.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="robots" content="nofollow,noarchive,noindex">
-  <title>{{ .Message }}</title>
+  <title data-l10n>{{ .Message }}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- {{ if or (eq .StatusCode 408) (eq .StatusCode 425) (eq .StatusCode 429) (eq .StatusCode 500) (eq .StatusCode 502) (eq .StatusCode 503) (eq .StatusCode 504) }} -->
   <meta http-equiv="refresh" content="30">
@@ -96,6 +96,20 @@
     h2 {
       font-size: 2em;
       font-weight: bold;
+    }
+
+    nav {
+      display: inline-flex;
+      align-items: flex-start;
+      flex-direction: row;
+      margin: 1em 0;
+      gap: .7em;
+    }
+
+    nav a {
+      color: var(--color-text-primary);
+      opacity: .75;
+      font-size: 0.9em;
     }
 
     /* {{ if .Config.ShowRequestDetails }} */
@@ -423,6 +437,15 @@
     <h1>{{.StatusCode}}</h1>
     <h2><span data-l10n>UH OH</span>! <span data-l10n>{{ .Message }}</span></h2>
     <p data-l10n>{{ .Description }}</p>
+
+    <nav aria-label="Additional links">
+      <!-- {{ if .HomepageURL }} -->
+      <a href="{{ .HomepageURL }}" data-l10n>Go to homepage</a>
+      <!-- {{ end }} -->
+      <!-- {{- range .Links -}} -->
+      <a href="{{ .URL }}" data-l10n>{{ .Label }}</a>
+      <!-- {{- end -}} -->
+    </nav>
 
     <!-- {{- if .Config.ShowRequestDetails -}} -->
     <ul class="details">

--- a/templates/html/noise.tpl.html
+++ b/templates/html/noise.tpl.html
@@ -1,5 +1,16 @@
 <!DOCTYPE html>
 <!--
+{{ if .HomepageURL }}
+Homepage: {{ .HomepageURL }}
+{{ end }}
+
+{{ if .Links }}
+Links:
+{{ range .Links }}
+- {{ .Label }}: {{ .URL }}
+{{ end }}
+{{ end }}
+
 {{ if .Config.ShowRequestDetails }}
     {{ if .Host }}Host: {{ .Host }}{{ end }}
     {{ if .OriginalURI }}Original URI: {{ .OriginalURI }}{{ end }}

--- a/templates/html/orient.tpl.html
+++ b/templates/html/orient.tpl.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="robots" content="nofollow,noarchive,noindex">
-  <title>{{ .Message }}</title>
+  <title data-l10n>{{ .Message }}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- {{ if or (eq .StatusCode 408) (eq .StatusCode 425) (eq .StatusCode 429) (eq .StatusCode 500) (eq .StatusCode 502) (eq .StatusCode 503) (eq .StatusCode 504) }} -->
   <meta http-equiv="refresh" content="30">
@@ -120,6 +120,19 @@
       /* {{- end }} */
     }
 
+    nav {
+      display: inline-flex;
+      align-items: flex-start;
+      flex-direction: row;
+      margin: 0 0 2em 0;
+      gap: .7em;
+    }
+
+    nav a {
+      color: var(--color-text-secondary);
+      font-size: 0.9em;
+    }
+
     /* {{ if .Config.ShowRequestDetails }} */
     .details {
       color: var(--color-text-secondary);
@@ -208,6 +221,14 @@
       <div class="code">{{.StatusCode}}</div>
       <div class="space"></div>
       <p class="description" data-l10n>{{ .Description }}</p>
+      <nav aria-label="Additional links">
+        <!-- {{ if .HomepageURL }} -->
+        <a href="{{ .HomepageURL }}" data-l10n>Go to homepage</a>
+        <!-- {{ end }} -->
+        <!-- {{- range .Links -}} -->
+        <a href="{{ .URL }}" data-l10n>{{ .Label }}</a>
+        <!-- {{- end -}} -->
+      </nav>
       <!-- {{ if .Config.ShowRequestDetails }} -->
       <div class="details">
         <table>

--- a/templates/html/shuffle.tpl.html
+++ b/templates/html/shuffle.tpl.html
@@ -70,6 +70,23 @@
       margin: 0;
     }
 
+    .hidden td, .hidden a {
+      opacity: 0;
+      font-size: 0;
+    }
+
+    .links {
+      display: flex;
+      gap: 1em;
+      margin-top: 1em;
+    }
+
+    .links a {
+      transition: opacity 1.4s, font-size .3s;
+      color: var(--color-inverted);
+      font-size: 0.85em;
+    }
+
     /* {{ if .Config.ShowRequestDetails }} */
     #details {
       table-layout: fixed;
@@ -82,11 +99,6 @@
       white-space: nowrap;
       font-size: 0.7em;
       transition: opacity 1.4s, font-size .3s;
-    }
-
-    #details.hidden td {
-      opacity: 0;
-      font-size: 0;
     }
 
     #details .name,
@@ -122,6 +134,15 @@
       <h1 class="source">{{ .StatusCode }}: <span data-l10n>{{ .Message }}</span></h1>
       <h1 class="target"></h1>
     </div>
+
+    <nav aria-label="Additional links" class="links hidden">
+      <!-- {{ if .HomepageURL }} -->
+      <a href="{{ .HomepageURL }}" data-l10n>Go to homepage</a>
+      <!-- {{ end }} -->
+      <!-- {{- range .Links -}} -->
+      <a href="{{ .URL }}" data-l10n>{{ .Label }}</a>
+      <!-- {{- end -}} -->
+    </nav>
 
     <!-- {{- if .Config.ShowRequestDetails -}} -->
     <table id="details" class="hidden">
@@ -254,11 +275,22 @@
 
   (new Shuffle(document.getElementById('error_text'))).start();
 
-  // {{ if .Config.ShowRequestDetails }}
   window.setTimeout(function () {
-    document.getElementById('details').classList.remove('hidden');
+    const $details = document.getElementById('details');
+    const $links = document.getElementsByClassName('links');
+
+    if ($details && $details.classList.contains('hidden')) {
+      $details.classList.remove('hidden');
+    }
+
+    if ($links) {
+      for (const $el of $links) {
+        if ($el.classList.contains('hidden')) {
+          $el.classList.remove('hidden');
+        }
+      }
+    }
   }, 550);
-  // {{ end }}
 </script>
 
 <!-- {{- if (not .Config.L10nDisabled) -}} -->

--- a/templates/html/win98.tpl.html
+++ b/templates/html/win98.tpl.html
@@ -174,6 +174,20 @@
       color: #252525;
     }
 
+    dialog section .content nav {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      justify-content: flex-start;
+      font-size: 0.8em;
+      padding-top: 1em;
+      gap: 0.6em;
+    }
+
+    dialog section .content nav a {
+      color: #252525;
+    }
+
     dialog .actions {
       display: flex;
       flex-direction: row;
@@ -341,7 +355,15 @@
           </svg>
         </div>
         <div class="content">
-          <p><span data-l10n>{{ .Description }}</span><!-- {{- if .Config.ShowRequestDetails -}} -->.<!-- {{- end -}} --></p>
+          <p><span data-l10n>{{ .Description }}</span>.</p>
+          <nav aria-label="Additional links">
+            <!-- {{ if .HomepageURL }} -->
+            <a href="{{ .HomepageURL }}" data-l10n>Go to homepage</a>
+            <!-- {{ end }} -->
+            <!-- {{- range .Links -}} -->
+            <a href="{{ .URL }}" data-l10n>{{ .Label }}</a>
+            <!-- {{- end -}} -->
+          </nav>
           <!-- {{- if .Config.ShowRequestDetails -}} -->
           <div class="details">
             <!-- {{- if .Host -}} -->


### PR DESCRIPTION
## Summary

Implements [#343](https://github.com/tarampampam/error-pages/issues/343) - adds a new `--add-link` flag (and `ADD_LINK` env var) that lets users display labeled links (status page, support contact, privacy policy, etc.) on all error pages.

Alongside the new feature, the Helm chart's `config.addCode` field was **refactored from a raw string to an array of objects** for consistency with the new `config.addLink` field. This is a **breaking change** for Helm chart users who already use `config.addCode`.

**Additionally, I added the homepage link to all built-in templates**.

### The `cats` template has been rewritten

<img width="750" height="400" alt="light" src="https://github.com/user-attachments/assets/7bea967e-a427-4ba2-a3a3-d71b9986ecfc" />
<img width="750" height="400" alt="dark" src="https://github.com/user-attachments/assets/f9b945b2-3e19-44d5-842b-0c43c55d9b70" />

## ⚠️ Breaking change - Helm chart: `config.addCode` format

> **This affects you only if you use the Helm chart AND have `config.addCode` set in your values.**

### Before (raw string)

```yaml
config:
  addCode: |
    499=Client Closed Request|The client closed the connection before the server finished responding.
    4**=Client Error|Something went wrong on the client side.
```

### After (array of objects)

```yaml
config:
  addCode:
    - code: "499"
      message: "Client Closed Request"
      description: "The client closed the connection before the server finished responding"
    - code: "4**"
      message: "Client Error"
      description: "Something went wrong on the client side"
```

Each item must have `code` (required) and `message` (required); `description` is optional. All values are strings. The chart serializes the array to the `CODE=MESSAGE|DESCRIPTION` wire format that the application expects - you do not need to know the internal format.

## New Helm field: `config.addLink`

```yaml
config:
  addLink:
    - {label: "Status Page", url: "https://status.example.com"}
    - {label: "Contact Support", url: "https://example.com/contact"}
    - {label: "Privacy Policy", url: "https://example.com/privacy"}
```
