### PR TITLE
feat(helm): add service annotations and loadBalancerSourceRanges support

### DIFF
--- a/deploy/helm/templates/service.yaml
+++ b/deploy/helm/templates/service.yaml
@@ -5,12 +5,20 @@ kind: Service
 metadata:
   name: {{ include "error-pages.fullname" . }}
   namespace: {{ template "error-pages.namespace" . }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "error-pages.commonLabels" . | nindent 4 }}
 
 spec:
   {{- with .Values.service }}
   type: {{ .type }}
+  {{- if and (eq .type "LoadBalancer") .loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml .loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
   ports:
     - name: http
       port: {{ .port }}

--- a/deploy/helm/values.schema.json
+++ b/deploy/helm/values.schema.json
@@ -185,9 +185,18 @@
       "type": "object",
       "properties": {
         "enabled": {"type": "boolean"},
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {"type": "string", "minLength": 1}
+        },
         "type": {
           "type": "string",
           "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+        },
+        "loadBalancerSourceRanges": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1, "pattern": "^\\S+$"},
+          "uniqueItems": true
         },
         "port": {"type": "integer", "minimum": 1, "maximum": 65535}
       }

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -69,9 +69,13 @@ deployment:
 service:
   # -- Enable service (`service.yaml` is not rendered when disabled)
   enabled: true
+  # -- Additional service annotations (e.g. for MetalLB, monitoring or service discovery, supports templating).
+  annotations: {}
   # -- Sets the service type more information can be
   # [found here](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)
   type: ClusterIP
+  # -- Limit access to the load balancer to specific CIDR ranges. Works only with type: LoadBalancer.
+  loadBalancerSourceRanges: []
   # -- Sets the port, more information can be
   # [found here](https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports)
   port: 8080


### PR DESCRIPTION
## Description

Thanks for the official Helm chart.

This PR adds the ability to specify the following in the Helm chart's `service.yaml`:

- Custom annotations (`.Values.service.annotations`), which can be used, for example, for MetalLB configuration.
- A list of CIDR ranges (`.Values.service.loadBalancerSourceRanges`) to restrict access to the load balancer.

## Checklist

- [x] My code adheres to the style guidelines of this project
- [x] I have conducted a self-review of my code
- [x] I have added comments to my code, especially in areas that may be difficult to understand
- [ ] I have written unit tests for my code _(if tests are required for my changes)_ <!-- feel free to drop this item from the list -->
